### PR TITLE
Fixed HTML grammar errors thanks to https://validator.w3.org/nu/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject/private/

--- a/RGAA3.0_Baseline_English_version_v1.html
+++ b/RGAA3.0_Baseline_English_version_v1.html
@@ -1,193 +1,191 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta http-equiv="content-type" content="charset=UTF-8" />
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-    <title>RGAA 3.0 Baseline - English translation</title>
-    <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Baseline." name="description" />
-    <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, baseline" name="keywords" />
-<style type="text/css">
-table {
-	margin-top:2em;
-}
-td,th {
-	padding:0.25em;
-	border: 1px solid black;
-}
-table {
-	border: 2px solid black;
-}
-</style>
- </head>
-  <body>
-    <header role="banner">
-      <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
-      <nav id="nav" role="navigation">
-        <ul>
-          <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
-          <li><a href="./RGAA3.0_Glossary_English_version_v1.html">Glossary</a></li>
-          <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
-          <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
-          <li>Baseline</li>
-          <li><a href="./RGAA3.0_References_English_version_v1.html">References</a></li>
-        </ul>
-      </nav>
-      <h1>Baseline</h1>
-<p>
-Several RGAA criteria refer  to rendering tests on a range of assistive technologies, browsers and operating systems. This document describes and explains the combinations selected to constitute the baseline.
-</p>
-      <p>
-        This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
-      </p>
-      <p>
-        The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
-	<p>
-        Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
-      </p>
-      <p>
-        Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
-      </p>
-        <h2 id="toc">
-          Table of Contents
-        </h2>
-        <nav role="navigation" aria-labelledby="toc">
-          <ul>
-             <li><a href="#compatible">Compatible with assistive technologies - Baseline</a></li>
-             <li><a href="#baseline">Baseline</a></li>
-            <li><a href="#additional">Additional requirements</a></li>
-            <li><a href="#controlled">Controlled environment</a></li>
-          </ul>
-        </nav>
-    </header>
+        <title>RGAA 3.0 Baseline - English translation</title>
+        <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Baseline." name="description" />
+        <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, baseline" name="keywords" />
+        <style type="text/css">
+            table {
+                margin-top:2em;
+            }
+            td,th {
+                padding:0.25em;
+                border: 1px solid black;
+            }
+            table {
+                border: 2px solid black;
+            }
+        </style>
+    </head>
+    <body>
+        <header role="banner">
+            <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
+            <nav id="nav" role="navigation">
+                <ul>
+                    <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
+                    <li><a href="./RGAA3.0_Glossary_English_version_v1.html">Glossary</a></li>
+                    <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
+                    <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
+                    <li>Baseline</li>
+                    <li><a href="./RGAA3.0_References_English_version_v1.html">References</a></li>
+                </ul>
+            </nav>
+            <h1>Baseline</h1>
+            <p>
+                Several RGAA criteria refer  to rendering tests on a range of assistive technologies, browsers and operating systems. This document describes and explains the combinations selected to constitute the baseline.
+            </p>
+            <p>
+                This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
+            </p>
+            <p>
+                The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
+            <p>
+                Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
+            </p>
+            <p>
+                Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
+            </p>
+            <h2 id="toc">
+                Table of Contents
+            </h2>
+            <nav role="navigation" aria-labelledby="toc">
+                <ul>
+                    <li><a href="#compatible">Compatible with assistive technologies - Baseline</a></li>
+                    <li><a href="#baseline">Baseline</a></li>
+                    <li><a href="#additional">Additional requirements</a></li>
+                    <li><a href="#controlled">Controlled environment</a></li>
+                </ul>
+            </nav>
+        </header>
 
-    <main role="main">
+        <main role="main">
 
-<h2 id="compatible">Compatible with assistive technologies - Baseline</h2>
+            <h2 id="compatible">Compatible with assistive technologies - Baseline</h2>
 
-<p>The reference baseline consists of configurations (assistive technology, operating system, browser) used to declare a HTML5&nbsp;/ ARIA  based piece of software is <a href="http://www.w3.org/Translations/WCAG20-fr/#accessibility-supporteddef">"accessibility supported" as defined by WCAG&nbsp;2.0</a>.</p>
+            <p>The reference baseline consists of configurations (assistive technology, operating system, browser) used to declare a HTML5&nbsp;/ ARIA  based piece of software is <a href="http://www.w3.org/Translations/WCAG20-fr/#accessibility-supporteddef">"accessibility supported" as defined by WCAG&nbsp;2.0</a>.</p>
 
-<p>It is established by consensus from the list of assistive technologies that are in a sufficiently widespread used, or in some cases (eg.: OS&nbsp;X) when provided natively, and is the users' preferred means of access to information and functionality.</p>
+            <p>It is established by consensus from the list of assistive technologies that are in a sufficiently widespread used, or in some cases (eg.: OS&nbsp;X) when provided natively, and is the users' preferred means of access to information and functionality.</p>
 
-<p>The methodology used to establish the baseline is  described in detail in this document: "Base de référence pour la compatibilité avec l'accessibilité" (translation: Baseline for compatibility with assistive technologies). You may download it as an <a href="http://references.modernisation.gouv.fr/sites/default/files/base_de_reference_RGAA.odt"></a>ODT (25 kb, in French) or <a href="http://references.modernisation.gouv.fr/sites/default/files/base_de_reference_RGAA.pdf">PDF (610 kb, in French)</a> file.
-</p>
-<h2 id="baseline">Baseline</h2>
+            <p>The methodology used to establish the baseline is  described in detail in this document: "Base de référence pour la compatibilité avec l'accessibilité" (translation: Baseline for compatibility with assistive technologies). You may download it as an <a href="http://references.modernisation.gouv.fr/sites/default/files/base_de_reference_RGAA.odt"></a>ODT (25 kb, in French) or <a href="http://references.modernisation.gouv.fr/sites/default/files/base_de_reference_RGAA.pdf">PDF (610 kb, in French)</a> file.
+            </p>
+            <h2 id="baseline">Baseline</h2>
 
-<p>The baseline that cover the widest proportion of uses consists of combinations involving assistive technologies sufficiently widespread, the two operating systems Windows XP (and later) and OS&nbsp;X + and the three browsers IE9+, Firefox and Safari.
-</p>
-<p>For a HTML5&nbsp;/&nbsp;ARIA device or its alternative to be considered compatible with accessibility, it has to be fully functional in terms of restitution and features, at least for one of the following combinations:
-</p>
-
-
-
-<table cellspacing="0">
-	<caption>Baseline - Combination 1</caption>
-	<thead>
-		<tr>
-			<th>Assistive technology</th><th>AT version</th><th>Browser</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>NVDA</td><td>Latest version</td><td>Firefox</td>
-		</tr>
-		<tr>
-			<td>JAWS</td><td>Previous version</td><td>Firefox or Internet Explorer 9+</td>
-		</tr>
-		<tr>
-			<td>Voice Over</td><td>Latest version</td><td>Safari</td>
-		</tr>
-	</tbody>
-</table>
-<table cellspacing="0">
-<caption>Baseline - Combination 2</caption>
-	<thead>
-		<tr>
-			<th>Assistive technology</th><th>AT version</th><th>Browser</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>JAWS</td><td>Previous version</td><td>Firefox</td>
-		</tr>
-		<tr>
-			<td>NVDA</td><td>Latest version</td><td>Firefox or Internet Explorer 9+</td>
-		</tr>
-		<tr>
-			<td>Voice Over</td><td>Latest version</td><td>Safari</td>
-		</tr>
-	</tbody>
-</table>
-
-<table cellspacing="0">
-<caption>Baseline - Combination 3</caption>
-	<thead>
-		<tr>
-			<th>Assistive technology</th><th>AT version</th><th>Browser</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>JAWS</td><td>Previous version</td><td>Firefox</td>
-		</tr>
-		<tr>
-			<td>Window-Eyes</td><td>Previous version</td><td>Firefox or Internet Explorer 9+</td>
-		</tr>
-		<tr>
-			<td>Voice Over</td><td>Latest version</td><td>Safari</td>
-		</tr>
-	</tbody>
-</table>
-
-<table cellspacing="0">
-<caption>Baseline - Combination 4</caption>
-	<thead>
-		<tr>
-			<th>Assistive technology</th><th>AT version</th><th>Browser</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>Window-Eyes</td><td>Previous version</td><td>Firefox</td>
-		</tr>
-		<tr>
-			<td>JAWS</td><td>Previous version</td><td>Firefox or Internet Explorer 9+</td>
-		</tr>
-		<tr>
-			<td>Voice Over</td><td>Latest version</td><td>Safari</td>
-		</tr>
-	</tbody>
-</table>
+            <p>The baseline that cover the widest proportion of uses consists of combinations involving assistive technologies sufficiently widespread, the two operating systems Windows XP (and later) and OS&nbsp;X + and the three browsers IE9+, Firefox and Safari.
+            </p>
+            <p>For a HTML5&nbsp;/&nbsp;ARIA device or its alternative to be considered compatible with accessibility, it has to be fully functional in terms of restitution and features, at least for one of the following combinations:
+            </p>
 
 
 
-<p><strong>Note:</strong> Since the NVDA screen reader does not require the purchase of a commercial license and covers all versions of Windows, the first two combinations should be preferred. The combination NVDA + Window-Eyes can not be accepted because it does not cover a sufficiently large proportion of uses.</p>
+            <table>
+                <caption>Baseline - Combination 1</caption>
+                <thead>
+                    <tr>
+                        <th>Assistive technology</th><th>AT version</th><th>Browser</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>NVDA</td><td>Latest version</td><td>Firefox</td>
+                    </tr>
+                    <tr>
+                        <td>JAWS</td><td>Previous version</td><td>Firefox or Internet Explorer 9+</td>
+                    </tr>
+                    <tr>
+                        <td>Voice Over</td><td>Latest version</td><td>Safari</td>
+                    </tr>
+                </tbody>
+            </table>
+            <table>
+                <caption>Baseline - Combination 2</caption>
+                <thead>
+                    <tr>
+                        <th>Assistive technology</th><th>AT version</th><th>Browser</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>JAWS</td><td>Previous version</td><td>Firefox</td>
+                    </tr>
+                    <tr>
+                        <td>NVDA</td><td>Latest version</td><td>Firefox or Internet Explorer 9+</td>
+                    </tr>
+                    <tr>
+                        <td>Voice Over</td><td>Latest version</td><td>Safari</td>
+                    </tr>
+                </tbody>
+            </table>
 
-<h2 id="additional">Additional requirements</h2>
+            <table>
+                <caption>Baseline - Combination 3</caption>
+                <thead>
+                    <tr>
+                        <th>Assistive technology</th><th>AT version</th><th>Browser</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>JAWS</td><td>Previous version</td><td>Firefox</td>
+                    </tr>
+                    <tr>
+                        <td>Window-Eyes</td><td>Previous version</td><td>Firefox or Internet Explorer 9+</td>
+                    </tr>
+                    <tr>
+                        <td>Voice Over</td><td>Latest version</td><td>Safari</td>
+                    </tr>
+                </tbody>
+            </table>
 
-<p>The following rules must be observed:
-</p>
-<ol>
-	<li>All HTML5&nbsp;/&nbsp;ARIA devices, or their alternatives, must be fully functional on all pages of the site without needing to use a different assistive technology;</li>
-	<li>When alternatives to HTML5&nbsp;/&nbsp;ARIA devices are proposed, they should not require deactivation of a technology (eg.: JavaScript or Flash plugin) unless there is a feature offered by the website itself. For example:
-		<ul>
-			<li>the site provides a fully functional, compliant alternative version, that does not require technologies  that are not accessibility supported;
-			</li>
-			<li>the site offers feature allowing to replace HTML5 / ARIA devices by compatible alternative devices;
-			</li>
-		</ul>
-	</li>
-	<li>Users of assistive technologies are provided with a means to report issues, and get through a compensation system, the information they would be blocked from otherwise;
-	</li>
-	<li>if a conformance declaration is provided, it must include a list of assistive technologies with which the HTML5&nbsp;/&nbsp;ARIA devices were tested, and the results of these tests (eg. "supported", "not supported", "partially supported"), at least.
-	</li>
-</ol>
+            <table>
+                <caption>Baseline - Combination 4</caption>
+                <thead>
+                    <tr>
+                        <th>Assistive technology</th><th>AT version</th><th>Browser</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Window-Eyes</td><td>Previous version</td><td>Firefox</td>
+                    </tr>
+                    <tr>
+                        <td>JAWS</td><td>Previous version</td><td>Firefox or Internet Explorer 9+</td>
+                    </tr>
+                    <tr>
+                        <td>Voice Over</td><td>Latest version</td><td>Safari</td>
+                    </tr>
+                </tbody>
+            </table>
 
-<h2 id="controlled">Controlled environment</h2>
+            <p><strong>Note:</strong> Since the NVDA screen reader does not require the purchase of a commercial license and covers all versions of Windows, the first two combinations should be preferred. The combination NVDA + Window-Eyes can not be accepted because it does not cover a sufficiently large proportion of uses.</p>
 
-<p>When the website is intended to be distributed and used in a controlled environment, the baseline consists of configurations (assistive technology, operating system, browser) actually used in the controlled environment.</p>
+            <h2 id="additional">Additional requirements</h2>
 
-<p>For example, when the website is exclusively distributed in a GNU&nbsp;/&nbsp;Linux environment, the tests must be carried out only on browsers and assistive technologies actually used by users in this environment. This baseline replaces the baseline used in uncontrolled environments.
-</p>
-  </main>
-</body>
+            <p>The following rules must be observed:
+            </p>
+            <ol>
+                <li>All HTML5&nbsp;/&nbsp;ARIA devices, or their alternatives, must be fully functional on all pages of the site without needing to use a different assistive technology;</li>
+                <li>When alternatives to HTML5&nbsp;/&nbsp;ARIA devices are proposed, they should not require deactivation of a technology (eg.: JavaScript or Flash plugin) unless there is a feature offered by the website itself. For example:
+                    <ul>
+                        <li>the site provides a fully functional, compliant alternative version, that does not require technologies  that are not accessibility supported;
+                        </li>
+                        <li>the site offers feature allowing to replace HTML5 / ARIA devices by compatible alternative devices;
+                        </li>
+                    </ul>
+                </li>
+                <li>Users of assistive technologies are provided with a means to report issues, and get through a compensation system, the information they would be blocked from otherwise;
+                </li>
+                <li>if a conformance declaration is provided, it must include a list of assistive technologies with which the HTML5&nbsp;/&nbsp;ARIA devices were tested, and the results of these tests (eg. "supported", "not supported", "partially supported"), at least.
+                </li>
+            </ol>
+
+            <h2 id="controlled">Controlled environment</h2>
+
+            <p>When the website is intended to be distributed and used in a controlled environment, the baseline consists of configurations (assistive technology, operating system, browser) actually used in the controlled environment.</p>
+
+            <p>For example, when the website is exclusively distributed in a GNU&nbsp;/&nbsp;Linux environment, the tests must be carried out only on browsers and assistive technologies actually used by users in this environment. This baseline replaces the baseline used in uncontrolled environments.
+            </p>
+        </main>
+    </body>
 </html>

--- a/RGAA3.0_Baseline_English_version_v1.html
+++ b/RGAA3.0_Baseline_English_version_v1.html
@@ -68,7 +68,7 @@
 
             <p>It is established by consensus from the list of assistive technologies that are in a sufficiently widespread used, or in some cases (eg.: OS&nbsp;X) when provided natively, and is the users' preferred means of access to information and functionality.</p>
 
-            <p>The methodology used to establish the baseline is  described in detail in this document: "Base de référence pour la compatibilité avec l'accessibilité" (translation: Baseline for compatibility with assistive technologies). You may download it as an <a href="http://references.modernisation.gouv.fr/sites/default/files/base_de_reference_RGAA.odt"></a>ODT (25 kb, in French) or <a href="http://references.modernisation.gouv.fr/sites/default/files/base_de_reference_RGAA.pdf">PDF (610 kb, in French)</a> file.
+            <p>The methodology used to establish the baseline is  described in detail in this document: "Base de référence pour la compatibilité avec l'accessibilité" (translation: Baseline for compatibility with assistive technologies). You may download it as an <a href="http://references.modernisation.gouv.fr/sites/default/files/base_de_reference_RGAA.odt">ODT (25 kb, in French)</a> or <a href="http://references.modernisation.gouv.fr/sites/default/files/base_de_reference_RGAA.pdf">PDF (610 kb, in French)</a> file.
             </p>
             <h2 id="baseline">Baseline</h2>
 

--- a/RGAA3.0_Criteria_English_version_v1.html
+++ b/RGAA3.0_Criteria_English_version_v1.html
@@ -1,5289 +1,5289 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta http-equiv="content-type" content="charset=UTF-8" />
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-    <title>RGAA 3.0 Criteria - English translation</title>
-    <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Criteria and tests." name="description" />
-    <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, criteria, tests" name="keywords" />
+        <title>RGAA 3.0 Criteria - English translation</title>
+        <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Criteria and tests." name="description" />
+        <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, criteria, tests" name="keywords" />
 
- </head>
-  <body>
-    <header role="banner">
-      <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
-      <nav id="nav" role="navigation">
-        <ul>
-          <li>Criteria</li>
-          <li><a href="./RGAA3.0_Glossary_English_version_v1.html">Glossary</a></li>
-          <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
-          <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
-          <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
-          <li><a href="./RGAA3.0_References_English_version_v1.html">References</a></li>
-        </ul>
-      </nav>
-      <h1>
-        <abbr lang="fr" title="Référentiel Général d'Accessibilité des Administrations">RGAA</abbr> 3.0 - Criteria - English translation
-      </h1>
-      <p>The RGAA is the French government's General Accessibility Reference for Administrations. It is meant to provide a way to check compliance against <abbr title="Web Content Accessibility Guidelines, version 2.0">WCAG 2.0</abbr>.</p>
-      <p>
-        This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
-      </p>
-      <p>
-        The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
-      <p>
-        Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
-      </p>
-      <p>
-        Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
-      </p>
-        <h2 id="toc">
-          Table of Contents
-        </h2>
-        <nav role="navigation" aria-labelledby="toc">
-          <ul>
-            <li><a href="#howto">How to use the RGAA</a></li>
-            <li><a href="#images">Images</a></li>
-            <li><a href="#cadres">Frames</a></li>
-            <li><a href="#couleurs">Colors</a></li>
-            <li><a href="#multimedia">Multimedia</a></li>
-            <li><a href="#tableaux">Tables</a></li>
-            <li><a href="#liens">Links</a></li>
-            <li><a href="#script">Scripts</a></li>
-            <li><a href="#elements">Mandatory elements</a></li>
-            <li><a href="#structure">Information structure</a></li>
-            <li><a href="#presentation">Presentation of information</a></li>
-            <li><a href="#formulaire">Forms</a></li>
-            <li><a href="#navigation">Navigation</a></li>
-            <li><a href="#consultation">Consultation</a></li>
-          </ul>
-        </nav>
-    </header>
-
-    <main role="main">
-      <h2 id="howto">How to use the RGAA</h2>
-      <p>
-        The RGAA applies to any HTML content (HTML4, XHTML1, HTML5). For some tests, a reference baseline is used. This baseline takes into account a set of assistive technologies, browsers and operating systems, on which the accessibility of JavaScript-based interface components must be tested, among others. A detailed description is provided here: <a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a>.
-      </p>
-        <h3>Important notice regarding HTML content prior to HTML5 specification</h3>
-        <p>When the HTML code of the page is <em>not</em> HTML5, the HTML5 elements (tags and attributes) required by a criterion or test, are not applicable. Every other criteria or tests remain applicable, including those related to ARIA attributes, states or properties. The following criteria and tests are not applicable:
-      </p>
-      <ul>
-        <li>criterion 1.10;</li>
-        <li>criterion 9.2;</li>
-        <li>test 10.13.3;</li>
-        <li>test 11.10.1 (condition 2, relative to the HTML5 attribute <code>required</code>).</li>
-      </ul>
-      <h3>Validation process</h3>
-      <p>
-        For each criterion, compliance is defined as follows:
-      </p>
-      <ul>
-        <li>Compliant (C): all applicable tests are passed</li>
-        <li>Non Compliant (NC): at least one applicable test is failed</li>
-        <li>Not Applicable (NA): there is no content targeted by the criterion.</li>
-      </ul>
-      <p>
-        The RGAA proposes two additional compliance statuses:
-      </p>
-      <ul>
-        <li>Derogated (D): some contents targeted by the criterion will meet compliance by derogation</li>
-        <li>Not tested (NT): the criterion has not been tested.</li>
-      </ul>
-      <p class="navTheme">
-          <a href="#cadres">Go to category: Frames</a>
-      </p>
-      <article id="images">
-        <header>
-        <h2>Images</h2>
-          <p>WCAG principle: perceivable.</p>
-          <h3>General guidelines</h3>
-          <p>Give each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
-              conveying information</a> a relevant <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text
-              alternative</a> and a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed description</a> if necessary. Replace images of text with styled text when possible.
-          </p>
+    </head>
+    <body>
+        <header role="banner">
+            <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
+            <nav id="nav" role="navigation">
+                <ul>
+                    <li>Criteria</li>
+                    <li><a href="./RGAA3.0_Glossary_English_version_v1.html">Glossary</a></li>
+                    <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
+                    <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
+                    <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
+                    <li><a href="./RGAA3.0_References_English_version_v1.html">References</a></li>
+                </ul>
+            </nav>
+            <h1>
+                <abbr lang="fr" title="Référentiel Général d'Accessibilité des Administrations">RGAA</abbr> 3.0 - Criteria - English translation
+            </h1>
+            <p>The RGAA is the French government's General Accessibility Reference for Administrations. It is meant to provide a way to check compliance against <abbr title="Web Content Accessibility Guidelines, version 2.0">WCAG 2.0</abbr>.</p>
+            <p>
+                This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
+            </p>
+            <p>
+                The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
+            <p>
+                Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
+            </p>
+            <p>
+                Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
+            </p>
+            <h2 id="toc">
+                Table of Contents
+            </h2>
+            <nav role="navigation" aria-labelledby="toc">
+                <ul>
+                    <li><a href="#howto">How to use the RGAA</a></li>
+                    <li><a href="#images">Images</a></li>
+                    <li><a href="#cadres">Frames</a></li>
+                    <li><a href="#couleurs">Colors</a></li>
+                    <li><a href="#multimedia">Multimedia</a></li>
+                    <li><a href="#tableaux">Tables</a></li>
+                    <li><a href="#liens">Links</a></li>
+                    <li><a href="#script">Scripts</a></li>
+                    <li><a href="#elements">Mandatory elements</a></li>
+                    <li><a href="#structure">Information structure</a></li>
+                    <li><a href="#presentation">Presentation of information</a></li>
+                    <li><a href="#formulaire">Forms</a></li>
+                    <li><a href="#navigation">Navigation</a></li>
+                    <li><a href="#consultation">Consultation</a></li>
+                </ul>
+            </nav>
         </header>
-        <section>
-        <h3 id="crit-1-1">
-          Criterion 1.1 [A] Does each image have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text alternative</a>?
-        </h3>
-        <ul>
-          <li id="test-1-1-1">
-            Test 1.1.1: Does each image (<code>img</code> tag) have an <code>alt</code> attribute?
-          </li>
-          <li id="test-1-1-2">
-            Test 1.1.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mZone">area</a> (<code>area</code> tag) of an
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgReactive">image map</a> have an <code>alt</code> attribute?
-          </li>
-          <li id="test-1-1-3">
-            Test 1.1.3: Does each form button
-            (<code>input</code> tag with the <code>type="image"</code> attribute) have an <code>alt</code>
-            attribute?
-          </li>
-          <li id="test-1-1-4">
-            Test 1.1.4: Does each area (<code>area</code> tag) of a server-side image map have an equivalent link in the page?
-          </li>
-        </ul>
-          <aside>
-        <h4>Mapping with WCAG 2.0</h4>
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or failure(s):  H36 - H37 - H53 - H24 - F65</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-2">
-          Criterion 1.2 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgDeco">decorative
-            image</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text
-            alternative</a>, is this alternative empty?
-        </h3>
-        <ul>
-          <li id="test-1-2-1">
-            Test 1.2.1: Does each decorative image (<code>img</code> tag), without caption and with an
-                <code>alt</code> attribute, meet the following conditions:
-            <ul>
-              <li>The <code>alt</code> attribute has an empty value (<code>alt=""</code>)</li>
-              <li>The decorative image does not have a <code>title</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-2-2">
-            Test 1.2.2: Does each non clickable area  (<code>area</code> tag with no
-            <code>href</code> attribute), not conveying any  information, and with an <code>alt</code> attribute,
-                meet the following conditions:
-            <ul>
-              <li>The <code>alt</code> attribute has an empty value (<code>alt=""</code>)</li>
-              <li>The non clickable area does not have a <code>title</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-2-3">
-            Test 1.2.3: For each image object without caption (<code>object</code> tag with the attribute <code>type="image/&hellip;"</code>), not conveying any information, is the text alternative between
-            <code>&lt;object&gt;</code> and  <code>&lt;/object&gt;</code> empty?
-          </li>
-          <li id="test-1-2-4">
-            Test 1.2.4: Does each decorative vector image (<code>svg</code> tag), not conveying any information, and with an alternative, meet the following conditions:
-            <ul>
-              <li>The <code>svg</code> tag has a <code>role="img"</code></li>
-              <li>The <code>svg</code> tag, or one of its children, has no ARIA role, property or state, that aims at labeling the vector image (<code>aria-label</code>, <code>aria-describedby</code>, or
-                <code>aria-labelledby</code>, for example)</li>
-              <li>The <code>title</code> and <code>desc</code> tags are missing, or empty</li>
-              <li>The <code>svg</code> tag, or one of its children, has no <code>title</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-2-5">
-            Test 1.2.5: For each decorative bitmap image (<code>canvas</code> tag), there must be no text content
-                between <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code>. Has this
-                rule been followed?
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-2">technical note about the <code>presentation</code> role</a>.
-        </p>
-          <aside>
-        <h4>Mapping with WCAG 2.0</h4>
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or failure(s): H67 - G196 - C9 - F39 - F38 - ARIA4 - ARIA10</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-3">
-          Criterion 1.3 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image conveying information</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text alternative</a>, is this alternative relevant (except in
-          <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
-            cases</a>)?
-        </h3>
-        <ul>
-          <li id="test-1-3-1">
-                Test 1.3.1: Does each image (<code>img</code> tag)
-                conveying information, with an <code>alt</code> attribute, meet
-                the following conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
-            cases</a>):
-          <ul>
-            <li>The <code>alt</code> attribute has a relevant value</li>
-            <li>If present, the value of the <code>title</code> attribute
-                  matches the value of the <code>alt</code> attribute</li>
-          </ul>
-            </li>
-          <li id="test-1-3-2">
-            Test 1.3.2: Does each area (<code>area</code> tag),
-                conveying information, and with an <code>alt</code> attribute,
-                meet the following conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
-            cases</a>):
-            <ul>
-              <li>The <code>alt</code> attribute has a relevant value</li>
-              <li>If present, the value of the <code>title</code> attribute
-                matches the value of the <code>alt</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-3-3">
-            Test 1.3.3: For each button associated
-            with an image (<code>input</code> tag with the attribute
-            <code>type="image"</code>), and with an <code>alt</code> attribute, is the content
-            of this attribute relevant (except in <a title="Particular cases for criterion 1.3"  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular cases</a>)?
-          </li>
-          <li id="test-1-3-4">
-            Test 1.3.4: Does each image object
-                (<code>object</code> tag with the attribute <code>type="image/&hellip;"</code>),
-                conveying information, meet one of the following
-                conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
-            cases</a>)?
-            <ul>
-              <li>The image object is immediately followed by an
-                  adjacent link giving access to a page or a chunk
-                  of text containing a relevant alternative</li>
-              <li>The user can replace the image
-                  object by a relevant text alternative, via a provided mechanism</li>
-              <li>The user can replace the image
-                  object by an image with a relevant alternative, via a provided mechanism</li>
-            </ul>
-          </li>
-          <li id="test-1-3-5">
-            Test 1.3.5: Does each embedded image
-                (<code>embed</code> tag with the attribute <code>type="image/&hellip;"</code>),
-                conveying information, meet one of the following
-                conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
-            cases</a>)?
-            <ul>
-              <li>The embedded image is immediately followed by an
-                  adjacent link giving access to a page or a chunk
-                  of text containing a relevant alternative</li>
-                <li>The user can replace the embedded image
-                   by a relevant text alternative, via a provided mechanism</li>
-              <li>The user can replace the embedded image
-                   by an image with a relevant alternative, via a provided mechanism</li>
-
-            </ul>
-          </li>
-          <li id="test-1-3-6">
-            Test 1.3.6: Does each vector image (<code>svg</code>
-                tag), conveying information, and with an alternative, meet
-                one of the following conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
-            cases</a>):
-            <ul>
-              <li>The <code>svg</code> tag has a <code>role="img"</code> </li>
-              <li>The <code>svg</code> tag has an <code>aria-label</code> property with a
-                relevant value, matching the <code>title</code> attribute of the
-                <code>svg</code> tag, if present</li>
-              <li>The <code>svg</code> tag has a <code>desc</code> tag with a relevant
-                content, equal to the <code>title</code> attribute of the <code>svg</code>
-                tag, if present</li>
-              <li>An adjacent link gives access to an alternative
-                with relevant content, equal to the <code>title</code> attribute
-                of the <code>svg</code> tag, if present</li>
-            </ul>
-          </li>
-          <li id="test-1-3-7">
-            Test 1.3.7: For each vector image (<code>svg</code> tag), conveying
-                information, and with an alternative,
-                    is this alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by
-                    assistive technologies?
-          </li>
-          <li id="test-1-3-8">
-            Test 1.3.8: For each bitmap image (<code>canvas</code> tag),
-                conveying information, and with an alternative
-                    (content between <code>&lt;canvas&gt;</code> and
-                    <code>&lt;/canvas&gt;</code>), is this alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?
-          </li>
-          <li id="test-1-3-9">
-            Test 1.3.9: For each bitmap image (<code>canvas</code> tag),
-                conveying information, and with an alternative
-                    (content between <code>&lt;canvas&gt;</code> and
-                    <code>&lt;/canvas&gt;</code>), is this alternative relevant?
-          </li>
-          <li id="test-1-3-10">
-            Test 1.3.10: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
-              conveying information</a> and with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text
-              alternative</a>, is <a href="./RGAA3.0_Glossary_English_version_v1.html#maltCC">the
-              text alternative short and concise</a> (except in
-              <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
-              cases</a>)?
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-3">technical note about the  vector images</a>.
-        </p>
-         <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G94 - G95 - F30 - F71 - G196 -
-            ARIA4</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-4">Criterion 1.4 [A] For each image used as <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
-          or as <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgTest">test image</a>, with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text
-            alternative</a>, does this alternative describe the nature and the purpose of the image?</h3>
-        <ul>
-          <li id="test-1-4-1">
-                Test 1.4.1: Does each image (<code>img</code> tag)
-                used as a CAPTCHA or test image, with an <code>alt</code>
-                attribute, meet the following conditions?
-            <ul>
-              <li>
-                The content of the <code>alt</code> attribute describes the nature and purpose of the image</li>
-                  <li>If present, the value of the <code>title</code> attribute
-                    matches the value of the <code>alt</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-4-2">
-            Test 1.4.2: Does each area (<code>area</code> tag) of an image map used as a CAPTCHA or test
-                image, with an <code>alt</code> attribute, meet the following conditions?
-            <ul>
-              <li>The content of the <code>alt</code> attribute describes the nature and purpose of the image </li>
-              <li>If present, the value of the <code>title</code> attribute
-                matches the value of the <code>alt</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-4-3">
-            Test 1.4.3: For each button associated
-            with an image (<code>input</code> tag with the attribute
-            <code>type="image"</code>), used as a CAPTCHA or test image, with an
-            <code>alt</code> attribute, meet the following conditions?
-            <ul>
-              <li>The content of the <code>alt</code> attribute describes the nature and purpose of the image </li>
-              <li>If present, the value of the <code>title</code> attribute
-                matches the value of the <code>alt</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-4-4">
-            Test 1.4.4: For each image object (<code>object</code>
-                tag with the attribute <code>type="image/&hellip;"</code>), used
-                    as a CAPTCHA or test image, with a text
-                    alternative, does the text alternative describe the nature and purpose of the image?
-          </li>
-          <li id="test-1-4-5">
-            Test 1.4.5: For each embedded image
-                (<code>embed</code> tag with the attribute <code>type="image/&hellip;"</code>), used
-                    as a CAPTCHA or test image, with a text
-                    alternative, does the text alternative describe the nature and purpose of the image?
-          </li>
-          <li id="test-1-4-6">
-            Test 1.4.6: Does each vector image (<code>svg</code>
-                tag), used as a CAPTCHA or test image, with a text alternative provided
-                  via the <code>aria-label</code> property or the <code>desc</code> tag, meet the following conditions?
-            <ul>
-              <li>The text alternative provided via the
-                        <code>aria-label</code> property describes the nature and purpose of the
-                        image, and matches the value of the <code>title</code>
-                        attribute of the <code>svg</code> tag, if present
-              </li>
-              <li>The text alternative provided via the <code>desc</code>
-                        tag describes the nature and purpose of the
-                        image, and matches the value of the <code>title</code>
-                        attribute of the <code>svg</code> tag, if present
-              </li>
-            </ul>
-          </li>
-          <li id="test-1-4-7">
-            Test 1.4.7: For each vector image (<code>svg</code> tag), used  as a CAPTCHA or test image, with a text
-                    alternative, is this alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?
-          </li>
-          <li id="test-1-4-8">
-            Test 1.4.8: For each bitmap image (<code>canvas</code> tag), used
-                    as a CAPTCHA or test image, with a text
-                    alternative, does this alternative describe the nature and purpose of the image?
-          </li>
-          <li id="test-1-4-9">Test 1.4.9: For each bitmap image (<code>canvas</code> tag), used
-                    as a CAPTCHA or test image, with a text
-                    alternative, is this alternative
-                    <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or failure(s): G143 - G100</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-5">
-          Criterion 1.5 [A] For each image used as  <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>,
-          is a solution for alternative access to the content or to
-          the purpose of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>  available?
-        </h3>
-        <ul>
-          <li id="test-1-5-1">
-            Test 1.5.1: Does each image (<code>img</code>,
-            area, <code>object</code>, <code>embed</code>, <code>svg</code>, <code>canvas</code> tags) used as <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>  meet one of the following conditions?
-            <ul>
-              <li>Another non graphic form of <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
-                is available, at least</li>
-              <li>Another solution to access the functionality
-                protected by the <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
-                is available</li>
-            </ul>
-          </li>
-          <li id="test-1-5-2"> Test 1.5.2: Does each button
-            associated with an image (<code>input</code> tag with the attribute
-            <code>type="image"</code>) used as <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
-            meet one of the following conditions?
-            <ul>
-              <li>Another non graphic form of <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
-                is available, at least
-              </li>
-              <li>Another solution to access the functionality
-                protected by the <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
-                is available</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G144</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-6">Criterion 1.6 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
-            conveying information</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-            description</a> if necessary?</h3>
-        <ul>
-          <li id="test-1-6-1"> Test 1.6.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
-              conveying information</a> (<code>img</code> tag) needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed description</a>, meet one of the following conditions?
-            <ul>
-              <li> A <code>longdesc</code> attribute providing the <a href="./RGAA3.0_Glossary_English_version_v1.html#mUrl">URL</a>
-                of a page that contains the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> is available</li>
-              <li> An <code>alt</code> attribute that contains the reference to a
-                <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> adjacent to the image is available</li>
-              <li> There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a  href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a></li>
-            </ul>
-          </li>
-          <li id="test-1-6-2"> Test 1.6.2: Does each image object
-            (<code>object</code> tag with an attribute <code>type="image/&hellip;"</code>)
-            conveying information needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-              description</a>, meet one of the following conditions?
-            <ul>
-              <li>There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a></li>
-              <li>There is a clearly identifiable <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> adjacent to the image object
-              </li>
-            </ul>
-          </li>
-          <li id="test-1-6-3"> Test 1.6.3: Does each embedded image
-            (<code>embed</code> tag with an attribute <code>type="image/&hellip;"</code>) conveying
-            information needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-              description</a>, meet one of the following conditions?
-            <ul>
-              <li>There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a
-
-                  href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a></li>
-              <li>There is a clearly identifiable <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> adjacent to the embedded image
-              </li>
-            </ul>
-          </li>
-          <li id="test-1-6-4">Test 1.6.4:
-            Does each image button (<code>input</code> tag with the attribute
-            <code>type="image"</code>), needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-              description</a>, meet one of the following conditions?
-            <ul>
-              <li>
-                An <code>alt</code> attribute containing the reference to a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">
-                detailed  description</a> adjacent  to the image is available</li>
-              <li> There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (<a href="./RGAA3.0_Glossary_English_version_v1.html#mUrl">URL</a>
-                or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> </li>
-            </ul>
-          </li>
-          <li id="test-1-6-5">Test 1.6.5: Does each vector image
-            (<code>svg</code> tag) conveying information needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-              description</a>, meet one of the following conditions?
-            <ul>
-              <li>There is an <code>aria-label</code> property referencing a
-                detailed description adjacent to the vector image</li>
-              <li>There is a <code>desc</code> tag containing a reference to a
-                detailed description adjacent to the vector image</li>
-              <li>There is a <code>desc</code> tag containing a detailed
-                description</li>
-              <li>There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a>
-              </li>
-            </ul>
-          </li>
-          <li id="test-1-6-6">Test 1.6.6: For each vector image (<code>svg</code> tag), with a
-                reference to a detailed description provided via an
-                <code>aria-label</code> property or a <code>desc</code> tag, is this reference
-              <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?</li>
-          <li id="test-1-6-7">Test 1.6.7: Does each bitmap image
-            (<code>canvas</code> tag) conveying information needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-              description</a>, meet one of the following conditions?
-            <ul>
-              <li>There is a chunk of text between <code>&lt;canvas&gt;</code>
-                and <code>&lt;/canvas&gt;</code> referencing a detailed
-                description adjacent to the bitmap image</li>
-              <li>There is a text content between <code>&lt;canvas&gt;</code> and
-                <code>&lt;/canvas&gt;</code> serving as a detailed description</li>
-              <li>There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a  href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a></li>
-            </ul>
-          </li>
-          <li id="test-1-6-8">Test 1.6.8: For each bitmap image (<code>canvas</code> tag),
-                with a reference to an adjacent detailed
-                description, is this reference <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?
-          </li>
-        </ul>
-                <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-6">technical note about vector images and the use of the <code>aria-describedby</code> property</a>.        </p>
-
-          <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G92 - G74 - G73 - H45 - ARIA6</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-7">Criterion 1.7 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
-            conveying information</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-            description</a>, is this description relevant?</h3>
-        <ul>
-          <li id="test-1-7-1">Test 1.7.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
-              conveying information</a> (<code>img</code> or <code>input</code>  tag with the
-            attribute  <code>type="image"</code>) with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-              description</a> meet one of the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> referenced via the URL in the
-                <code>longdesc</code> attribute is relevant</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> available in the page and
-                identified in the <code>alt</code> attribute is relevant</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> available via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> is relevant</li>
-            </ul>
-          </li>
-          <li id="test-1-7-2">Test 1.7.2: Does each image object
-            (<code>object</code> tag with the attribute  <code>type="image/&hellip;"</code>) with a
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-              description</a> meet one of the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> adjacent to the object image is
-                relevant</li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
-                  description</a> available via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> is relevant</li>
-            </ul>
-          </li>
-          <li id="test-1-7-3">Test 1.7.3: Does each embedded image
-            (<code>embed</code> tag with the attribute  <code>type="image/&hellip;"</code>) with a
-            detailed description meet one of the following
-            conditions?
-            <ul>
-              <li>The detailed description adjacent to the embedded
-                image is relevant</li>
-              <li>The detailed description available via an adjacent
-                link is relevant</li>
-            </ul>
-          </li>
-          <li id="test-1-7-4">Test 1.7.4: Does each vector image
-            (<code>svg</code> tag) with a detailed description meet one of the
-            following conditions?
-            <ul>
-              <li>The detailed description adjacent to the vector
-                image is relevant</li>
-              <li>The detailed description available via an adjacent
-                link is relevant</li>
-            </ul>
-          </li>
-          <li id="test-1-7-5">Test 1.7.5: For each vector image (<code>svg</code>
-            tag) with a detailed description, is this detailed
-            description <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive
-            technologies?</li>
-          <li id="test-1-7-6">Test 1.7.6: Does each bitmap image
-            (<code>canvas</code> tag) with a detailed description meet one of the
-            following conditions?    
-            <ul>
-              <li>The detailed description adjacent to the bitmap
-                image is relevant</li>
-              <li>The detailed description available between
-                <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code> is relevant</li>
-              <li>The detailed description available via an adjacent
-                link is relevant</li>
-            </ul>
-          </li>
-          <li id="test-1-7-7">Test 1.7.7: For each bitmap image
-            (<code>canvas</code> tag) with a detailed description between
-            <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code>, is this detailed
-            description <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive
-            technologies?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G92- F67</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-8">Criterion 1.8 [AA] When an alternate
-          mechanism is missing, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgText">image
-            of text</a> conveying information must be replaced with
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-            text</a>, if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-1-8-1"> Test 1.8.1: When an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
-              mechanism</a> is missing, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgText">image
-              of text</a> (<code>img</code> tag) conveying information must be
-            replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a>, if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
-          <li id="test-1-8-2"> Test 1.8.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgReactive">image
-              map</a> (<code>img</code> or <code>object</code> tag with the <code>usemap</code> or <code>ismap</code> attribute),
-            when an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
-              mechanism</a> is missing, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneTexte">text
-              area</a> (<code>area</code> tag) conveying information must be
-            replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
-          <li id="test-1-8-3"> Test 1.8.3: For each <code>form</code> tag, when
-            an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
-              mechanism</a> is missing, each button "image of text"
-            (<code>input</code> tag with the attribute <code>type="image"</code>) conveying
-            information must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a>, if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
-          <li id="test-1-8-4"> Test 1.8.4: When an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
-              mechanism</a> is missing, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgTextObj">object
-              image of text</a> (<code>object</code> tag with the attribute
-            <code>type="image/&hellip;"</code>) conveying information must be replaced
-            with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
-          <li id="test-1-8-5"> Test 1.8.5: When an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
-              mechanism</a> is missing, each embedded image of text
-            (<code>embed</code> tag with the attribute <code>type="image/&hellip;"</code>)
-            conveying information must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
-          <li id="test-1-8-6">Test 1.8.6: When an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
-              mechanism</a> is missing, each bitmap image of text
-            (<code>canvas</code> tag) conveying information must be replaced with
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
-        </ul>
-        <aside>
-
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-8">technical note about   vector images of type text</a>.
-        </p>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.4.5</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G136 - G140 - C22 - C30</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-9">Criterion 1.9 [AAA] Each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgText">image
-            of text</a> conveying information must be replaced with
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-            text</a>. Has this rule been followed (except in <a title="Particular cases for criterion 1.9"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-1-9-1"> Test 1.9.1: Each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgText">image
-              of text</a> (<code>img</code> tag) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
-          <li id="test-1-9-2"> Test 1.9.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgReactive">image
-              map</a> (<code>img</code> or <code>object</code> tag with the <code>usemap</code> attribute),
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneTexte">text
-              area</a> (<code>area</code> tag) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
-          <li id="test-1-9-3"> Test 1.9.3: For each <code>form</code> tag, each
-            button "image of text" (<code>input</code> tag with the attribute
-            <code>type="image"</code>) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
-          <li id="test-1-9-4"> Test 1.9.4: Each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgTextObj">text
-              image object</a> (<code>object</code> tag with the attribute
-            <code>type="image/&hellip;"</code>) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
-          <li id="test-1-9-5"> Test 1.9.5: Each embedded image of
-            text (<code>embed</code> tag with the attribute <code>type="image/&hellip;"</code>)
-            must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
-          <li id="test-1-9-6"> Test 1.9.6: Each bitmap image of text
-            (<code>canvas</code> tag) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
-              text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.4.9</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G140 - C22 - C30</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-1-10">Criterion 1.10
-          [A] Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImageCaption">image caption<a> correctly associated with the
-          corresponding image, if necessary?</h3>
-        <ul>
-          <li id="test-1-10-1">Test 1.10.1: Does each image with a
-            caption (<code>img</code> tag or <code>input</code> tag with the attribute
-            <code>type="image"</code>, associated with an adjacent caption) meet,
-            if necessary, the following conditions?
-            <ul>
-              <li> The image (<code>img</code> tag) and its caption are contained
-                in a <code>figure</code> tag</li>
-              <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
-              <li>The content of the <code>alt</code> attribute contains a
-                reference to the adjacent caption</li>
-              <li>The value of the <code>title</code> attribute of the image, if
-                present, is strictly equal to the value of the <code>alt</code>
-                attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-10-2">Test 1.10.2: Does each image object with a caption (<code>object</code> tag with the attribute <code>type="image/&hellip;"</code>,
-            associated with an adjacent caption) meet, if necessary,
-            the following conditions?
-            <ul>
-              <li> The image (<code>object</code> tag) and its caption are
-                contained in a <code>figure</code> tag</li>
-              <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
-            </ul>
-          </li>
-          <li id="test-1-10-3">Test 1.10.3: Does each embedded image
-            with a caption (<code>embed</code> tag with the attribute
-            <code>type="image/&hellip;"</code>, associated with an adjacent caption)
-            meet, if necessary, the following conditions?
-            <ul>
-              <li> The embedded image (<code>embed</code> tag) and its caption
-                are contained in a <code>figure</code> tag</li>
-              <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
-              <li>The content of the <code>alt</code> attribute contains a
-                reference to the adjacent caption</li>
-              <li>The value of the <code>title</code> attribute of the image, if
-                present, is strictly equal to the value of the <code>alt</code>
-                attribute</li>
-            </ul>
-          </li>
-          <li id="test-1-10-4">Test 1.10.4: Does each vector image
-            with a caption (<code>svg</code> tag associated with an adjacent
-            caption) meet, if necessary, the following conditions?
-            <ul>
-              <li> The vector image (<code>svg</code> tag) and its caption are
-                contained in a <code>figure</code> tag</li>
-              <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
-              <li>The content of the <code>aria-label</code> property or the <code>desc</code>
-                tag of the vector image contains a reference to the
-                adjacent caption</li>
-              <li>The value of the <code>title</code> attribute of the vector
-                image (<code>svg</code> tag), if present, is strictly equal to
-                the content of the <code>aria-label</code> property or the <code>desc</code>
-                tag used as an alternative</li>
-            </ul>
-          </li>
-          <li id="test-1-10-5">Test 1.10.5: Does each bitmap image
-            with a caption (<code>canvas</code> tag associated with an adjacent
-            caption) meet, if necessary, the following conditions?
-            <ul>
-              <li> The bitmap image (<code>canvas</code> tag) and its caption are
-                contained in a <code>figure</code> tag</li>
-              <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
-              <li>The content between <code>&lt;canvas&gt;</code> and
-                <code>&lt;/canvas&gt;</code> contains a reference to the adjacent
-                caption</li>
-            </ul>
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-10">technical note about captioned images</a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0 </h4>
-
-          <p>WCAG 2.0 success criterion: 1.1.1 - 4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or failure(s): G140 - ARIA4- ARIA6</p>
-      </article>
-        <ul class="navTheme">
-          <li class="haut"><a href="#toc">Table of contents</a></li>
-          <li class="haut"><a href="#images">Go to category: Images</a></li>
-          <li class="bas"><a href="#couleurs">Go to category: Colors</a></li>
-        </ul>
-      <article id="cadres" class="thematique">
-        <header>
-        <h2>Frames </h2>
-           <p>WCAG principle: robust.</p>
-          <h3>General guidelines</h3>
-         <p>
-            GProvide each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a> with a relevant title.
-          </p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-2-1">Criterion 2.1 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a>
-          have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreCadre">frame
-            title</a>?</h3>
-        <ul>
-          <li id="test-2-1-1">Test 2.1.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a>
-            (<code>iframe</code> tag) have a <code>title</code> attribute?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): H64</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-2-2">Criterion 2.2 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a>
-          with a frame title, is this <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreCadre">frame
-            title</a> relevant?</h3>
-        <ul>
-          <li id="test-2-2-1"> Test 2.2.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a>
-            (<code>iframe</code> tag) with a <code>title</code> attribute, is the content of
-            this attribute relevant?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): H64</p>
-
-      </article>
-        <ul class="navTheme">
-          <li class="haut"><a href="#toc">Table of contents</a></li>
-          <li class="haut"><a href="#cadres">Go to category: Frames</a></li>
-          <li class="bas"><a href="#multimedia">Go to category: Multimedia</a></li>
-        </ul>
-      <article id="couleurs" class="thematique">
-        <header>
-        <h2>Colors</h2>
-          <p>WCAG principle: perceivable.</p>
-          <h3>General guidelines</h3>
-          <p>Do not provide <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-             through color only, and use sufficient color contrasts.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-3-1">Criterion 3.1 [A] On each Web page, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> must
-          not  be conveyed only through color. Has this rule been
-          followed?</h3>
-        <ul>
-          <li id="test-3-1-1"> Test 3.1.1: For each word or for each
-            group of words where color is used to convey <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>,
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-            must not be conveyed only through color. Has this rule been
-            followed?</li>
-          <li id="test-3-1-2"> Test 3.1.2: For each color indication
-            provided by a text, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-            must not be conveyed only through color. Has this rule been
-            followed?</li>
-          <li id="test-3-1-3"> Test 3.1.3: For each image <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoDonneeCouleur">conveying
-              information</a>, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-            must not be conveyed only through color. Has this rule been
-            followed?</li>
-          <li id="test-3-1-4"> Test 3.1.4: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mPropCouleur">CSS
-              property defining a color</a> and conveying
-              information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-            must not be conveyed only through color. Has this rule been
-            followed?</li>
-          <li id="test-3-1-5"> Test 3.1.5: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> conveying information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-            must not be conveyed only through color. Has this rule been
-            followed?</li>
-          <li id="test-3-1-6"> Test 3.1.6: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non-time-based
-              media</a> conveying
-              information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-            must not be conveyed only through color. Has this rule been
-            followed?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria: 1.4.1 -
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G14 - G182 - G111 - G117 - G138 -
-            G205</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-3-2">Criterion 3.2 [A] On each Web page, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
-          must not be conveyed only through color. Has this rule been
-          implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</h3>
-        <ul>
-          <li id="test-3-2-1"> Test 3.2.1: For each word or a group
-            of words, whose color conveys information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-            must not be conveyed only through color. Has this rule been
-            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
-          <li id="test-3-2-2"> Test 3.2.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
-            conveyed through color and specified by a word or a group of
-            words, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
-            must not be conveyed only through color. Has this rule been
-            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
-          <li id="test-3-2-3"> Test 3.2.3: For each image <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoDonneeCouleur">conveying
-              information</a>, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
-            must not be conveyed only through color. Has this rule been
-            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
-          <li id="test-3-2-4"> Test 3.2.4: For each CSS element
-            background property conveying
-              information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
-            must not be conveyed only through color. Has this rule been
-            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
-          <li id="test-3-2-5"> Test 3.2.5: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> conveying
-              information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
-            must not be conveyed only through color. Has this rule been
-            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
-          <li id="test-3-2-6"> Test 3.2.6: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-              time-based media</a> conveying
-              information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
-            must not be conveyed only through color. Has this rule been
-            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.4.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G138 - F13</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-3-3">Criterion 3.3 [AA] On each Web page, is
-          the <a href="./RGAA3.0_Glossary_English_version_v1.html#mContraste">contrast</a>
-          between the text and background colors sufficient (except in <a title="Particular cases for criterion 3.3"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-3-3-1"> Test 3.3.1: On each Web page, do
-            non-bold texts and images of non-bold text with font sizes smaller than or equal to <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">150% of
-              the default font size</a> (or 1.5em)  meet one of the
-            following conditions (except
-              in <a title="Particular cases for criterion 3.3"  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
-            <ul>
-              <li> The contrast ratio between text and its
-                background is at least 4.5:1</li>
-              <li>The user can display the text with
-                a contrast ratio of at least 4.5:1, via a provided mechanism</li>
-            </ul>
-          </li>
-          <li id="test-3-3-2"> Test 3.3.2: On each Web page, do bold
-            texts and images of bold text with font sizes smaller than or equal to <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">120% of the default font size</a> (or
-            1.2em) meet one of the following conditions (except
-              in <a title="Particular cases for criterion 3.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
-            <ul>
-              <li> The contrast ratio between text and its
-                background is at least 4.5:1</li>
-              <li>The user can display the text with a
-                contrast ratio of at least 4.5:1, via a provided mechanism</li>
-            </ul>
-          </li>
-          <li id="test-3-3-3">Test 3.3.3: On each Web page, do
-            non-bold texts and images of non-bold text with font sizes larger than <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">150% of the default font size</a> (or 1.5em), meet one of
-            the following conditions (except in <a title="Particular cases for criterion 3.3"  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
-            <ul>
-              <li> The contrast ratio between text and its
-                background is at least 3:1</li>
-              <li>The user can display the text with a
-                contrast ratio of at least 3:1, via a provided mechanism</li>
-            </ul>
-          </li>
-          <li id="test-3-3-4"> Test 3.3.4: On each Web page, do bold
-            texts and images of bold text with font sizes larger than <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">120%
-              of the default font size</a> (or 1.2em), meet one
-            of the following conditions (except
-              in <a title="Particular cases for criterion 3.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
-            <ul>
-              <li> The contrast ratio between text and its
-                background is at least 3:1</li>
-              <li>The user can display the text with a
-                contrast ratio of at least 3:1, via a provided mechanism</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.4.3</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G18 - G136 - G148 - G174 - G145 -
-            C29</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-3-4">Criterion 3.4 [AAA] On each Web page, is
-          the <a href="./RGAA3.0_Glossary_English_version_v1.html#mContraste">contrast</a>
-          between the text and background colors enhanced (except
-            in <a title="Particular cases for criterion 3.4"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-3-4-1"> Test 3.4.1: On each Web page, do
-            non-bold texts and images of non-bold text with font sizes smaller than or equal to <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">150% of
-              the default font size</a> (or 1.5em) meet one of the
-            following conditions (except
-              in <a title="Particular cases for criterion 3.4"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
-            <ul>
-              <li> The contrast ratio between text and its
-                background is at least 7:1</li>
-              <li>The user can display the text with
-                a contrast ratio of at least 7:1, via a provided mechanism</li>
-            </ul>
-          </li>
-          <li id="test-3-4-2"> Test 3.4.2: On each Web page, do bold
-            texts and images of bold text with font sizes smaller than or equal to <a
-
-              href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">120% of the default font size</a> (or
-            1.2em) meet one of the following conditions (except
-              in <a title="Particular cases for criterion 3.4"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
-            <ul>
-              <li> The contrast ratio between text and its
-                background is at least 7:1</li>
-              <li>The user can display the text with
-                a contrast ratio of at least 7:1, via a provided mechanism</li>
-            </ul>
-          </li>
-          <li id="test-3-4-3">Test 3.4.3: On each Web page, do
-            non-bold texts and images of non-bold text with font sizes larger than <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">150%
-              of the default font size</a> (or 1.5em), meet one of
-            the following conditions (except
-              in <a title="Particular cases for criterion 3.4"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
-            <ul>
-              <li> The contrast ratio between text and its
-                background is at least 4.5:1</li>
-              <li>The user can display the text with
-                a contrast ratio of at least 4.5:1, via a provided mechanism</li>
-            </ul>
-          </li>
-          <li id="test-3-4-4"> Test 3.4.4: On each Web page, do bold
-            texts and images of bold text with font sizes larger than <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">120%
-              of the default font size</a> (or 1.2em), meet one
-            of the following conditions (except
-              in <a title="Particular cases for criterion 3.4"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
-            <ul>
-              <li> The contrast ratio between text and its
-                background is at least 4.5:1</li>
-              <li>The user can display the text with
-                a contrast ratio of at least 4.5:1, via a provided mechanism</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.4.6</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G148 - G17 - G18 - G174 - F83</p>
-      </article>
-      <ul class="navTheme">
-        <li class="haut"><a href="#toc">Table of contents</a></li>
-        <li class="haut"><a href="#couleurs">Go to category: Colors</a></li>
-        <li class="bas"><a href="#tableaux">Go to category: Tables</a></li>
-      </ul>
-      <article id="multimedia" class="thematique">
-
-        <header>
-        <h2>Multimedia</h2>
-         <h3>General guidelines</h3>
-          <p>If necessary, provide each time-based media with
-            relevant <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-              transcript</a>, <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-              captions</a> and a synchronized audio description.
-            Provide each non time-based media with a relevant text
-            alternative. Make possible the <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleConsult">viewing
-              control</a> of each time-based and non time-based
-            media with the keyboard and ensure that they are
-            compatible with assistive technologies.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-1">Criterion 4.1 [A] Does each prerecorded <a
-
-            href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-            transcript</a> or an audio description if necessary (except
-            in <a
-
-            title="Particular cases for criterion 4.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-1-1"> Test 4.1.1: Does each prerecorded
-            audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions if
-            necessary (except
-              in <a title="Particular cases for criterion 4.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li>There is a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> that is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li>There is an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> that can be clearly identified</li>
-            </ul>
-          </li>
-          <li id="test-4-1-2"> Test 4.1.2: Does each prerecorded
-            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions if necessary
-              (except
-              in <a title="Particular cases for criterion 4.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li> There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioOnly">alternative audio-only version</a> that
-                is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li>There is an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> that can be clearly identified</li>
-              <li> A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> is available</li>
-              <li> There is an alternative version with a
-                synchronized audio description that is accessible
-                via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-            </ul>
-          </li>
-          <li id="test-4-1-3">Test 4.1.3: Does each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions if necessary
-              (except
-              in <a title="Particular cases for criterion 4.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li>There is a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> that is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li>There is an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> that can be clearly identified</li>
-              <li> A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> is available</li>
-              <li> There is an alternative version with a
-                synchronized audio description that is accessible
-                via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria: 1.2.1 -
-            1.2.3</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G58 - G69 - G78 - G158 - G159 -
-            G173 - G8 - G166 - SM6 - SM7</p>
-
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-2">Criterion 4.2 [A] For each prerecorded <a
-
-            href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-            transcript</a> or a synchronized audio description, are
-          these relevant (except
-            in <a title="Particular cases for criterion 4.2"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-2-1">Test 4.2.1: For each prerecorded
-            audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-              transcript</a>, is this transcript relevant (except
-              in <a title="Particular cases for criterion 4.2"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)? </li>
-          <li id="test-4-2-2">Test 4.2.2: Does each prerecorded
-            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions (except
-              in <a title="Particular cases for criterion 4.2"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> is relevant</li>
-              <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> is relevant</li>
-              <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> of the alternative version is
-                relevant</li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioOnly">alternative audio-only version</a> is relevant </li>
-
-            </ul>
-          </li>
-          <li id="test-4-2-3"> Test 4.2.3: Does each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions (except
-              in <a title="Particular cases for criterion 4.2"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> is relevant</li>
-              <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> is relevant</li>
-              <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> of the alternative version is
-                relevant</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-          <p>WCAG 2.0 success criteria: 1.2.1 - 1.2.3</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or failure(s): F30 - F67 - SM6 - SM7</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-3">
-          Criterion 4.3 [A] Does each prerecorded
-          synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> have <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-            captions</a> if necessary
-            (except
-            in <a title="Particular cases for criterion 4.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-        </h3>
-        <ul>
-          <li id="test-4-3-1">Test 4.3.1: Does each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions (except
-              in <a title="Particular cases for criterion 4.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> has <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-              captions</a></li>
-              <li>there is an alternative version with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-              captions</a> that is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">
-              adjacent link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li id="test-4-3-2">Test 4.3.2: For each prerecorded
-              synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-              captions</a> provided through a <code>track</code> tag, does the
-              <code>track</code> tag have an attribute <code>kind="captions"</code>?</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.2</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G58 - G93 - G87 - H95 - SM11 -
-            SM12 - F74 - F75</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-4">Criterion 4.4 [A] For each prerecorded
-          synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-            captions</a>, are these captions relevant?</h3>
-        <ul>
-          <li id="test-4-4-1"> Test 4.4.1: For each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-              captions</a>, are these captions relevant? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.2</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G87 - G93 - F8 - F74 - F75 - SM11
-            - SM12</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-5">Criterion 4.5 [AA] Does each live <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> have <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-            captions</a> or a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-            transcript</a> if necessary (except
-            in <a title="Particular cases for criterion 4.5"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-5-1"> Test 4.5.1: Does each live audio-only
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions (except
-              in <a title="Particular cases for criterion 4.5"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li> <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-                  captions</a> are available</li>
-              <li>a version with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-                  captions</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li> a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li>an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> can be clearly identified</li>
-            </ul>
-          </li>
-          <li id="test-4-5-2"> Test 4.5.2: Does each synchronized
-            live <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions (except
-              in <a title="Particular cases for criterion 4.5"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li> <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-                  captions</a> are available</li>
-              <li> a version with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-                  captions</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li> a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li>an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> can be clearly identified</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria: 1.2.4 -
-            1.2.9</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G9 - G150 - G151 - G157 - H95 -
-            SM11 - SM12</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-6">Criterion 4.6 [AA] Are each <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-            captions</a> or <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-            transcript</a>, provided for live <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a>, relevant?</h3>
-        <ul>
-          <li id="test-4-6-1"> Test 4.6.1: Does each audio-only live
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-                  captions</a> are relevant</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-                  captions</a> of the alternative version are
-                relevant</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> is relevant</li>
-            </ul>
-          </li>
-          <li id="test-4-6-2"> Test 4.6.2: Does each synchronized
-            live <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-                  captions</a> are relevant</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
-                  captions</a> of the alternative version are
-                relevant</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> is relevant</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria: 1.2.4 -
-            1.2.9</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): F8</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-7">Criterion 4.7 [AA] Does each prerecorded <a
-
-            href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> have a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-            description</a> if necessary (except
-            in <a title="Particular cases for criterion 4.7"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-7-1"> Test 4.7.1: Does each video-only
-            prerecorded <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions, if
-            necessary (except
-              in <a title="Particular cases for criterion 4.7" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>?
-            <ul>
-              <li>A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> is available</li>
-              <li>an alternative version with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> is available</li>
-            </ul>
-          </li>
-          <li id="test-4-7-2"> Test 4.7.2: Does each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions (except
-              in <a title="Particular cases for criterion 4.7"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li>A sound track for the synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> is available</li>
-              <li>An alternative version with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-                  description</a> is available</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.5</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G8 - G58 - G78 - G173 - H96 - SM1
-            - SM2 - SM6 - SM7</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-8">Criterion 4.8 [AA] For each prerecorded <a
-
-            href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> with a synchronized audio description, is this
-          audio description relevant?</h3>
-        <ul>
-          <li id="test-4-8-1"> Test 4.8.1: For each prerecorded
-            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-              description</a>, is this audio description relevant?</li>
-          <li id="test-4-8-2"> Test 4.8.2: For each synchronized <a
-
-              href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
-              description</a>, is this audio description relevant? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.5</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): SM1 - SM2 - SM6 - SM7</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-9">Criterion 4.9 [AAA] Does each prerecorded
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> have a sign language interpretation (except
-            in <a title="Particular cases for criterion 4.9"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>) if necessary?</h3>
-        <ul>
-          <li id="test-4-9-1"> Test 4.9.1: Does each prerecorded
-            audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> have a sign language interpretation if
-            necessary, that is adapted to the media language (except
-              in <a title="Particular cases for criterion 4.9"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</li>
-          <li id="test-4-9-2"> Test 4.9.2: Does each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> have a sign language interpretation, if
-            necessary, that is adapted to the media language (except
-              in <a title="Particular cases for criterion 4.9"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.6</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G54 - G81 - SM13 - SM14 </p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-10">Criterion 4.10 [AAA] For each prerecorded
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> with a sign language interpretation is this
-          interpretation relevant?</h3>
-        <ul>
-          <li id="test-4-10-1"> Test 4.10.1: For each prerecorded
-            audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a sign language interpretation, is this
-            interpretation relevant? </li>
-          <li id="test-4-10-2"> Test 4.10.2: For each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a sign language interpretation, is this
-            interpretation relevant?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.6</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G54 - G81 - SM13 - SM14</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-11">Criterion 4.11 [AAA] Does each
-          prerecorded <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> have a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
-            audio description</a> if necessary (except
-            in <a title="Particular cases for criterion 4.11"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-11-1"> Test 4.11.1: Does each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions, if
-            necessary? (except
-              in <a title="Particular cases for criterion 4.11"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)
-            <ul>
-              <li> A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
-                  audio description</a> is available</li>
-              <li> An alternative version with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
-                  audio description</a> is available</li>
-            </ul>
-          </li>
-          <li id="test-4-11-2"> Test 4.11.2: Does each prerecorded
-            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions, if
-            necessary? (except
-              in <a title="Particular cases for criterion 4.11"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)
-            <ul>
-              <li> A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
-                  audio description</a> is available</li>
-              <li> An alternative version with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
-                  audio description</a> is available</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.7</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G8 - G58 - H96 - SM1 - SM2</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-12">Criterion 4.12 [AAA] For each prerecorded
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> with a synchronized extended audio
-          description, is this audio description relevant?</h3>
-        <ul>
-          <li id="test-4-12-1"> Test 4.12.1: For each prerecorded
-            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
-              audio description</a>, is this audio description
-            relevant?</li>
-          <li id="test-4-12-2"> Test 4.12.2: For each prerecorded
-            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
-              audio description</a>, is this audio description
-            relevant?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.7</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G8 - SM1 - SM2</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-13">Criterion 4.13 [AAA] Does each
-          synchronized or video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-            transcript</a> (except
-            in <a title="Particular cases for criterion 4.13"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-13-1"> Test 4.13.1: Does each synchronized
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions, if
-            necessary (except
-              in <a title="Particular cases for criterion 4.13" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li>a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a>  is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li>an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> can be clearly identified</li>
-            </ul>
-          </li>
-          <li id="test-4-13-2"> Test 4.13.2: Does each video-only <a
-
-              href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> meet one of the following conditions, if
-            necessary (except
-              in <a title="Particular cases for criterion 4.13" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
-            <ul>
-              <li>a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li>an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-                  transcript</a> can be clearly identified</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.8</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G58 - G69 - G159</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-14">Criterion 4.14 [AAA] For each
-          synchronized or video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-            transcript</a>, is this text transcript relevant?</h3>
-        <ul>
-          <li id="test-4-14-1"> Test 4.14.1: For each video-only <a
-
-              href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-              transcript</a>, is this text transcript relevant?</li>
-          <li id="test-4-14-2"> Test 4.14.2: For each synchronized <a
-
-              href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
-              transcript</a>, is this text transcript relevant? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.2.8</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): F74</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-15">Criterion 4.15 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> be clearly identified (except
-            in <a title="Particular cases for criterion 4.15"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-15">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-15-1"> Test
-              4.15.1: For each audio-only, video-only or
-              synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-                media</a> , does the adjacent textual content help
-              to clearly identify the time-based media (except
-                in <a title="Particular cases for criterion 4.15"
-
-                href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-15">particular cases</a>)?</li>
-          <li id="test-4-15-2"> Test
-              4.15.2: For each live audio-only, live video-only or
-              live synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-                media</a> , does the adjacent textual content help
-              to clearly identify the time-based media (except
-                in <a title="Particular cases for criterion 4.15"
-
-                href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-15">particular cases</a>)?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G68 - G100</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-16">Criterion 4.16 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-            time-based media</a> have, if
-            necessary, an alternative (except
-            in <a title="Particular cases for criterion 4.16"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-16">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-16-1">Test 4.16.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-              time-based media</a> meet, if
-              necessary, one of the following conditions (except
-              in <a
-
-              title="Particular cases for criterion 4.16" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-16">particular cases</a>)?
-            <ul>
-              <li>An <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a>, clearly identifiable, links to a URL
-                containing an alternative</li>
-              <li> An <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a>, clearly identifiable, gives access to an
-                alternative in the page</li>
-            </ul>
-          </li>
-          <li id="test-4-16-2">Test 4.16.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-              time-based media</a> associated with an alternative
-            meet one of the following conditions (except
-              in <a title="Particular cases for criterion 4.16"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-16">particular cases</a>)?
-            <ul>
-              <li> The page to which the <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> refers is accessible</li>
-              <li> The alternative in the page to which the <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
-                  link</a> refers is accessible.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): H35 - H46</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-17">Criterion 4.17 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-            time-based media</a> with an alternative, is this
-          alternative relevant?</h3>
-        <ul>
-          <li id="test-4-17-1"> Test
-              4.17.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-                time-based media</a> with an alternative, does this
-              alternative provide access to the same content, and to
-              similar functionalities?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): H46 - F30</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-18">Criterion 4.18 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mControlSound">autoplaying sound  be controlled by the user</a>?</h3>
-        <ul>
-          <li id="test-4-18-1"> Test 4.18.1: Does each audio
-            sequence played automatically via an <code>object</code>, <code>video</code>,
-              <code>audio</code>, <code>embed</code> tag, a JavaScript code or <code>bgsound</code>
-            property meet one of the following conditions?
-            <ul>
-              <li> The audio sequence lasts  3
-                seconds or less</li>
-              <li> The audio sequence can be stopped by an action
-                initiated by the user</li>
-              <li> The volume of the audio sequence can be
-                controlled by the user independently from the system
-                volume control.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.4.2</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G60 - G170 - G171 - F23 - F93</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-19">Criterion 4.19 [AAA] For each prerecorded
-          audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a>, are the dialogues audible enough (except
-            in <a title="Particular cases for criterion 4.19"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-19">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-19-1"> Test 4.19.1: Does each prerecorded
-            audio <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a>, played via an <code>object</code>, <code>video</code>,
-              <code>audio</code>, <code>embed</code> tag, or provided for download,
-            meet one of the following conditions (except
-              in <a title="Particular cases for criterion 4.19"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-19">particular cases</a>)?
-            <ul>
-              <li> The background sounds can be turned off</li>
-              <li> The volume of the dialogue track(s) is 20
-                decibels higher than the volume of the background
-                sounds.</li>
-              <li>An alternative version, for which the background
-                sounds can be turned off, is available</li>
-              <li>An alternative version in which the volume of the
-                dialogue track(s) is 20 decibels higher than the
-                volume of the background sounds, is available.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion: 1.4.7</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G56</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-20">Criterion 4.20 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> be, if necessary,
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleClavSour">controlled
-            by keyboard and mouse</a>?</h3>
-        <ul>
-          <li id="test-4-20-1"> Test 4.20.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a> have the <a href="./RGAA3.0_Glossary_English_version_v1.html#mFonctionControle">control
-              features</a> to be played,
-            if necessary?</li>
-          <li id="test-4-20-2"> Test
-              4.20.2: For each time-based media, does each control
-              feature meet one of the following conditions:
-            <ul>
-              <li>    The control feature can be
-                    reached by the keyboard and by the mouse?</li>
-              <li>    A keyboard and mouse
-                  accessible control feature,
-                  performing the same action, is available in the
-                  same page
-                </li>
-            </ul>
-          </li>
-
-          <li id="test-4-20-3"> Test
-              4.20.3: For each time-based media, does each control
-              feature meet one of the following conditions:
-            <ul>
-              <li>    The control feature
-                  can be activated by the keyboard and by the mouse?</li>
-              <li>    A control feature,
-                  performing the same action, and that can be
-                  activated by the keyboard and by the mouse, is
-                  available in the same page
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-          <p>WCAG 2.0 success criteria: 2.1.1 -
-            2.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G90 - G4 - G202</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-21">Criterion 4.21 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-            time-based media</a> be controlled by the keyboard and
-          by the mouse?</h3>
-        <ul>
-          <li id="test-4-21-1"> Test
-              4.21.1: For each non time-based media, does each
-              control feature meet one of the following conditions:
-            <ul>
-              <li>    The control feature can be
-                    reached by the keyboard and by the mouse?</li>
-              <li>    A keyboard and mouse
-                  accessible control feature,
-                  performing the same action, is available in the
-                  same page
-                </li>
-            </ul>
-          </li>
-          <li id="test-4-21-2"> Test
-              4.21.2: For each non time-based media, does each
-              control feature meet one of the following conditions:
-            <ul>
-              <li>    The control feature
-                  can be activated by the keyboard and by the mouse?</li>
-              <li>    A control feature,
-                  performing the same action, and that can be
-                  activated by the keyboard and by the mouse, is
-                  available in the same page
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria: 2.1.1 -
-            2.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s) and/or
-              failure(s): G90 - G4</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-4-22">Criterion 4.22 [A] Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-            media</a> and each non time-based media compatible with
-          assistive technologies (except
-            in <a title="Particular cases for criterion 4.22"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-22">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-4-22-1"> Test
-              4.22.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-                media</a> and each non time-based media, inserted
-              via an <code>object</code> or <code>embed</code> tag, meet one of the following
-              conditions (except
-                in <a title="Particular cases for criterion 4.22"
-
-                href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-22">particular cases</a>)?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mNameRole">name, role, value,
-                  settings and states changes<a> of the interface components
-                  are accessible to assistive technologies via an
-                  accessibility API </li>
-              <li> An alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCompAccess">compatible with an accessibility API</a> provides the
-                  same functionalities</li>
-            </ul>
-          </li>
-          <li id="test-4-22-2">Test
-              4.22.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-                media</a> and each non time-based media, inserted
-              via an <code>object</code> or <code>embed</code> tag, with an alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCompAccess">compatible with an accessibility API</a>, meet one of the
-              following conditions?
-            <ul>
-
-              <li>The alternative is
-                  adjacent to the time-based media, or the non
-                  time-based media</li>
-              <li>The alternative can be
-                  reached via an adjacent link (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
-              <li>A functionality is
-                  available to replace the time-based or non
-                  time-based media by its alternative</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            4.1.2 - 2.1.1 - 2.1.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G10 - G135 - F15 - F54</p>
-
-      </article>
-      <ul class="navTheme">
-        <li class="haut"><a href="#toc">Table of contents</a></li>
-        <li class="haut"><a href="#multimedia">Go to category: Multimedia</a></li>
-        <li class="bas"><a href="#liens">Go to category: Links</a></li>
-      </ul>
-      <article id="tableaux" class="thematique">
-        <header>
-        <h2>Tables</h2>
-          <p>WCAG principle: perceivable.</p>
-          <h3>General guidelines</h3>
-          <p>Provide each  <a
-
-              href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
-              table</a>, with a relevant <a href="./RGAA3.0_Glossary_English_version_v1.html#mResumeTab">summary</a>
-            and a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreTab">title</a>,
-            clearly identify header cells, use a relevant mechanism
-            to associate data cells with header cells. Ensure that
-            each layout table is correctly linearized.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-5-1">Criterion 5.1 [A] Does each
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
-            table</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mResumeTab">summary</a>?
-          </h3>
-        <ul>
-          <li id="test-5-1-1">Test 5.1.1:
-              Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
-                table</a> (<code>table</code> tag) have a summary, provided
-              through the <code>caption</code> tag?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H73</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-5-2">Criterion 5.2 [A] For each
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
-            table</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mResumeTab">summary</a>,
-          is this summary relevant?</h3>
-        <ul>
-          <li id="test-5-2-1"> Test 5.2.1:
-              For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
-                table</a> (<code>table</code> tag) with a summary, is this
-              summary relevant?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H73</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-5-3">Criterion 5.3 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
-            table</a>, is the linearized content still
-          understandable?</h3>
-        <ul>
-          <li id="test-5-3-1"> Test
-              5.3.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
-                table</a> meet the following conditions?
-            <ul>
-              <li>the
-                  linearized content is still understandable</li>
-              <li>the <code>table</code>
-                  tag has an attribute <code>role="presentation"</code></li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.2 - 4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): F49 - ARIA4</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-5-4">Criterion 5.4 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
-            table</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreTab">title</a>?</h3>
-        <ul>
-          <li id="test-5-4-1"> Test 5.4.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
-              table</a> (<code>table</code> tag) have a <code>caption</code> tag?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H39</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-5-5">Criterion 5.5 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
-            table</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreTab">title</a>,
-          is this title relevant?</h3>
-        <ul>
-          <li id="test-5-5-1"> Test 5.5.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
-              table</a> (<code>table</code> tag) with a <code>caption</code> tag, does the
-            content of this tag provide the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreTab">title</a>
-            of the table? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H39</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-5-6">Criterion 5.6 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
-            table</a>, are each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnteteTab">column
-            header</a> and each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnteteTab">row
-            header</a> correctly identified?</h3>
-        <ul>
-          <li id="test-5-6-1"> Test 5.6.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
-              table</a> (<code>table</code> tag), does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnteteTab">column
-              header</a> have a <code>th</code> tag?</li>
-          <li id="test-5-6-2"> Test 5.6.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
-              table</a> (<code>table</code> tag), does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnteteTab">row
-              header</a> have a <code>th</code> tag?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H51 - F91</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-5-7">Criterion 5.7 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
-            table</a>, is each cell associated with its header using
-          the appropriate technique?</h3>
-        <ul>
-          <li id="test-5-7-1"> Test 5.7.1: Does each header cell (<code>th</code>
-            tag) applied to the whole row or to the whole column
-            have a unique <code>id</code> attribute or a <code>scope</code> attribute?</li>
-          <li id="test-5-7-2"> Test 5.7.2: Does each header cell (<code>th</code>
-            tag) applied to the whole row or the whole column and
-            having a <code>scope</code> attribute meet one of the following
-            conditions?
-            <ul>
-              <li> The header has a <code>scope</code> attribute with the value
-                "<code>row</code>" for row headers</li>
-              <li> The header has a <code>scope</code> attribute with the value
-                "<code>col</code>" for column headers</li>
-            </ul>
-          </li>
-          <li id="test-5-7-3"> Test 5.7.3: Does each header cell (<code>th</code>
-            tag) that is not applied to the whole column meet the
-            following conditions?
-            <ul>
-              <li> The header does not have a <code>scope</code> attribute</li>
-              <li> The header has a unique <code>id</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-5-7-4"> Test 5.7.4: Does each cell (<code>td</code> or <code>th</code>
-            tag) associated with one or several headers with an <code>id</code> attribute meet the following conditions?
-            <ul>
-              <li> The cell has a <code>headers</code> attribute</li>
-              <li> The <code>headers</code> attribute contains a list of values
-                matching the <code>id</code> attributes of the headers associated
-                with the cell.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H63 - H43</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-5-8">Criterion 5.8 [A] Each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
-            table</a> must not use elements intended for data
-          tables. Has this rule been followed?</h3>
-        <ul>
-          <li id="test-5-8-1">Test 5.8.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
-              table</a> (<code>table</code> tag) meet the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
-                  table</a> (<code>table</code> tag) does not have any <code>caption</code>,
-                <code>th</code>, <code>thead</code>, <code>tfoot</code> tags</li>
-              <li> The cells of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
-                  table</a> (<code>td</code> tag) have no <code>scope</code>, <code>headers</code>,
-                <code>colgroup</code>, <code>axis</code> attributes.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): F46</p>
-      </article>
-        <ul class="navTheme">
-          <li class="haut"><a href="#toc">Table of contents</a></li>
-          <li class="haut"><a href="#tableaux">Go to category: Tables</a></li>
-          <li class="bas"><a href="#script">Go to category: Scripts</a></li>
-        </ul>
-      <article id="liens" class="thematique">
-        <header>
-        <h2>Links</h2>
-          <p>WCAG principle: perceivable, operable,
-            understandable.</p>
-          <h3>General guidelines</h3>
-          <p>Provide explicit link text, in particular, with context
-            information, and use the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
-              title</a> as sparsely as possible. Add links or a
-            navigation form to the areas of a server-side image map.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-6-1">Criterion 6.1 [A] Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLien">link</a>
-          explicit (except in <a title="Particular cases for criterion 6.1"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
-            cases</a>)?</h3>
-        <ul>
-          <li id="test-6-1-1"> Test 6.1.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
-              context</a> meet one of the following conditions
-            (except in <a title="Particular cases for criterion 6.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
-              cases</a>)?
-            <ul>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
-                  text</a> alone is sufficient to understand the link
-                purpose and target</li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
-                  context</a> is sufficient to understand the link purpose
-                and target</li>
-            </ul>
-          </li>
-          <li id="test-6-1-2"> Test 6.1.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienImage">image
-              link</a> (content of the <code>alt</code> attribute, text between
-            <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code>, or text between
-            <code>&lt;object&gt;</code> and <code>&lt;/object&gt;</code>) meet one of the
-            following conditions (except in <a title="Particular cases for criterion 6.1"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
-              cases</a>)?
-            <ul>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
-                  text</a> alone is sufficient to understand the link
-                purpose and target</li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
-                  context</a> is sufficient to understand the link purpose
-                and target</li>
-            </ul>
-          </li>
-          <li id="test-6-1-3"> Test 6.1.3: Does each
-              link that doubles a <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneCliquable">clickable
-                area</a> of a server-side image map meet one
-            of the following conditions (except in <a title="Particular cases for criterion 6.1"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
-              cases</a>)?
-            <ul>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
-                  text</a> alone is sufficient to understand the link
-                purpose and target</li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
-                  context</a> is sufficient to understand the link purpose
-                and target</li>
-            </ul>
-          </li>
-          <li id="test-6-1-4"> Test 6.1.4: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienComposite">combined
-              link</a> meet one of the following conditions (except
-            in <a title="Particular cases for criterion 6.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
-              cases</a>)?
-            <ul>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
-                  text</a> alone is sufficient to understand the link
-                purpose and target</li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
-                  context</a> is sufficient to understand the link purpose
-                and target</li>
-            </ul>
-          </li>
-          <li id="test-6-1-5"> Test 6.1.5: Does each  <a href="./RGAA3.0_Glossary_English_version_v1.html#mVectorLink">vector
-            link</a> meet one of the following conditions (except in <a  title="Particular cases for criterion 6.1"
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
-              cases</a>)?
-            <ul>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
-                    text</a> alone is sufficient to understand the link
-                  purpose and target</li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
-                    context</a> is sufficient to understand the link purpose
-                  and target</li>
-            </ul>
-          </li>
-       </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.1.1 - 2.4.4 - 2.4.9</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H78 - H79 - H80 - H81 -
-            H30 - F89 - G91 - G53 - ARIA7 - ARIA8 - F63</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-6-2">Criterion 6.2 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLien">link</a>
-          with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
-            title</a>, is this title relevant?</h3>
-        <ul>
-          <li id="test-6-2-1"> Test 6.2.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienTexte">text
-              link</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
-              title</a> (<code>title</code> attribute), is the content of this
-            attribute relevant? </li>
-          <li id="test-6-2-2"> Test 6.2.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienImage">image
-              link</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
-              title</a> (<code>title</code> attribute), is the content of this
-            attribute relevant? </li>
-          <li id="test-6-2-3"> Test 6.2.3: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneCliquable">clickable
-              area</a> (<code>area</code> tag) with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
-              title</a> (<code>title</code> attribute), is the content of this
-            attribute relevant? </li>
-          <li id="test-6-2-4"> Test 6.2.4: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienComposite">combined
-              link</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
-              title</a> (<code>title</code> attribute), is the content of this
-            attribute relevant? </li>
-          <li id="test-6-2-5">Test 6.2.5:
-              For each  <a href="./RGAA3.0_Glossary_English_version_v1.html#mVectorLink">vector
-            link</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
-                title</a> (<code>title</code> attribute), is the content of this
-              attribute relevant? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H33</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-6-3">Criterion 6.3 [AAA] Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
-            text</a> alone <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
-            out of context</a> (except
-            in <a title="Particular cases for criterion 6.3"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-6-3-1"> Test 6.3.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienTexte">text
-              link</a> meet one of the following conditions (except
-              in <a title="Particular cases for criterion 6.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)?
-            <ul>
-              <li>The link text is explicit out of its context</li>
-              <li>The user can get an explicit
-                link text out of its context, via a provided mechanism</li>
-              <li>The content of the link title (<code>title</code> attribute) is
-                explicit out of its context</li>
-            </ul>
-          </li>
-          <li id="test-6-3-2"> Test 6.3.2: Is each text for an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienImage">image
-              link</a> (content of the <code>alt</code> attribute, text
-              between <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code> or text
-              between <code>&lt;object&gt;</code> and <code>&lt;/object&gt;</code>) <a
-
-              href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
-              out of context</a> (except
-              in <a title="Particular cases for criterion 6.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)? </li>
-          <li id="test-6-3-3"> Test 6.3.3: Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
-              text</a> such as a <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneCliquable">clickable
-              area</a> (content of the <code>alt</code> attribute of an <code>area</code> tag)
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
-              out of context</a> (except
-              in <a title="Particular cases for criterion 6.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)? </li>
-          <li id="test-6-3-4"> Test 6.3.4: Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienComposite">combined
-              link</a> (content of the text and of the <code>alt</code>
-            attribute) <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
-              out of context</a> (except
-              in <a title="Particular cases for criterion 6.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)? </li>
-          <li id="test-6-3-5">Test 6.3.5: Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mVectorLink">vector
-            link</a>
-            (content of the alternative of the vector image, <code>svg</code>
-            tag) <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
-              out of context</a> (except
-              in <a title="Particular cases for criterion 6.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.9</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G91 - G189 - H33 - SCR30</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-6-4">Criterion 6.4 [A] For
-            each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
-            link</a> have the same purpose and target?</h3>
-        <ul>
-          <li id="test-6-4-1"> Test 6.4.1: For
-              each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
-              link</a> of type text have the same purpose and
-            target?</li>
-          <li id="test-6-4-2"> Test 6.4.2: For
-              each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
-              link</a> of type image have the same purpose and
-            target?</li>
-          <li id="test-6-4-3"> Test 6.4.3: For
-              each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
-              link</a> of type <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneCliquable">clickable
-              area</a> have the same purpose and target?</li>
-          <li id="test-6-4-4"> Test 6.4.4: For
-              each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
-              link</a> of type combined link have the same purpose
-            and target?</li>
-          <li id="test-6-4-5">Test 6.4.5:For each web page, does
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
-              link</a> that are <a href="./RGAA3.0_Glossary_English_version_v1.html#mVectorLink">vector
-            links</a> have the same purpose and
-            target?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteri:
-            2.4.4 - 3.2.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H78 - H79 - H80 - G91 -
-            G197 - H30 - H33 - ARIA7 - ARIA8</p>
-
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-6-5">Criterion 6.5 [A] On each Web page, does
-          each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLien">link</a>,
-          except in <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom"> <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>s</a>,
-          have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">text</a>?</h3>
-        <ul>
-          <li id="test-6-5-1"> Test 6.5.1 On each Web page, does
-            each link (<code>a</code> tag with an <code>href</code>
-              attribute), except in <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom"> <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>s</a>,
-            have a text between <code>&lt;a&gt;</code> and <code>&lt;/a&gt;</code>? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.1.1 - 2.4.4 - 2.4.9</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G91 - H30 - F89</p>
-      </article>
-        <ul class="navTheme">
-        <li class="haut"><a href="#toc">Table of contents</a></li>
-          <li class="haut"><a href="#liens">Go to category: Links</a></li>
-          <li class="bas"><a href="#elements">Go to category: Mandatory
-                elements</a></li>
-        </ul>
-      <article id="script" class="thematique">
-        <header>
-        <h2>Scripts</h2>
-         <h3>General guidelines</h3>
-          <p>Provide, if necessary, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            with a relevant <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>.
-            Make each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            controllable at least by keyboard and mouse, and ensure
-            that it is compatible with assistive technologies.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-7-1">Criterion 7.1 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-          support assistive technologies, if necessary?</h3>
-        <ul>
-          <li id="test-7-1-1">Test 7.1.1:
-              Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-              generating or controlling an interface component meet
-              one of the following conditions, if necessary?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mNameRole">name, role, value,
-                  settings and states changes<a> are accessible to
-                  assistive technologies via an accessibility API </li>
-              <li> An accessible interface
-                  component, allowing access to the same
-                  functionalities, is available in the page</li>
-              <li> An accessible <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
-                  provides the same functionalities.</li>
-            </ul>
-          </li>
-          <li id="test-7-1-2"> Test 7.1.2:
-              Does each functionality for content insertion
-              controlled by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>,
-              use <a href="./RGAA3.0_Glossary_English_version_v1.html#mDOM">properties and methods compliant with the DOM
-              (Document Object Model) specification</a>? </li>
-          <li id="test-7-1-3">Test 7.1.3:
-              Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-              generating or controlling an interface component,
-              having roles, states or properties matching with an
-              ARIA API Design Pattern, meet one of the following
-              conditions?
-            <ul>
-              <li> The interface component
-                  complies with the Design Pattern defined by the
-                  ARIA API</li>
-              <li>An interface component,
-                  available in the page, providing access to the same
-                  functionalities, complies
-                  with the Design Pattern defined by the ARIA API</li>
-              <li>The interface component <a href="./RGAA3.0_Glossary_English_version_v1.html#mAdaptsARIADP">adapts a Design Pattern defined by the ARIA API</a></li>
-              <li>An accessible interface
-                  component providing access to the same
-                  functionalities is available in the page</li>
-            </ul>
-          </li>
-          <li id="test-7-1-4"> Test 7.1.4:
-              Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangeNativeRole">change of native role of an HTML element</a>
-              respect the rules and recommendations of the HTML5
-              specifications, and the associated technical notes?</li>
-          <li id="test-7-1-5">Test 7.1.5:
-              Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-              generating or controlling an interface component, via
-              roles, states or properties defined by the ARIA API,
-              meet one of the following conditions?
-            <ul>
-              <li> The interface component
-                  is <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies</li>
-              <li>An accessible
-                  alternative provides access to the same
-                  functionalities
-                </li>
-            </ul>
-          </li>
-          <li id="test-7-1-6">Test 7.1.6:
-              Does each interface component with an ARIA role
-              <code>application</code> meet one of the following conditions?
-            <ul>
-              <li> The interface component
-                  is <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies</li>
-              <li>An accessible
-                  alternative provides access to the same
-                  functionalities
-                </li>
-            </ul>
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit7-1">technical note about the alternatives to scripts</a>.
-        </p><aside>
-
-
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G10 - G135 - G136 - ARIA4
-            - ARIA5 - ARIA18 - ARIA19 - SCR21 - F15 - F19 - F42 -
-            F59 - F79 - F20</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-7-2">Criterion 7.2 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-          with an <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>,
-          is this <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
-          relevant?</h3>
-        <ul>
-          <li id="test-7-2-1"> Test 7.2.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-             beginning with the <code>script</code> tag, and having an <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>,
-            meet one of the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
-                between <code>&lt;noscript&gt;</code> and <code>&lt;/noscript&gt;</code>
-                provides access to similar content and functionalities</li>
-              <li> When JavaScript is disabled, the displayed page
-                provides access to  similar content and functionalities</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
-                page provides access to similar content and
-                functionalities</li>
-              <li> The server-side script language provides access to
-                similar content and functionalities</li>
-              <li>The alternative
-                  available in the same page provides access to 
-                  similar content and functionalities </li>
-            </ul>
-          </li>
-          <li id="test-7-2-2"> Test 7.2.2: Does each non text
-            element that is updated by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            (in the page or an <code>iframe</code>) and that has an <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
-            meet the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
-                of the non text element is updated</li>
-              <li> The updated <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
-                is relevant</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            4.1.2 - 1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G136 - F19 - F20</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-7-3">Criterion 7.3 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-          be <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleClavSour">controlled
-            by keyboard and mouse</a> (except
-            in <a title="Particular cases for criterion 7.3"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-3">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-7-3-1"> Test 7.3.1: Does each element with an
-            event handler controlled by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            meet one of the following conditions (except
-              in <a title="Particular cases for criterion 7.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-3">particular cases</a>)?
-            <ul>
-              <li> The element is <a href="./RGAA3.0_Glossary_English_version_v1.html#mAAClavierSouris">accessible
-                  with keyboard and mouse</a></li>
-              <li> An element that is <a href="./RGAA3.0_Glossary_English_version_v1.html#mAAClavierSouris">accessible
-                  with keyboard and mouse</a>, performing
-                the same action, is available in the page</li>
-            </ul>
-          </li>
-          <li id="test-7-3-2"> Test 7.3.2: Does each element with an
-            event handler controlled by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            meet one of the following conditions (except
-              in <a title="Particular cases for criterion 7.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-3">particular cases</a>)?
-            <ul>
-              <li> The element can be <a href="./RGAA3.0_Glossary_English_version_v1.html#mAAClavierSouris">activated
-                  by keyboard and mouse</a></li>
-              <li> An element that can be <a href="./RGAA3.0_Glossary_English_version_v1.html#mAAClavierSouris">activated
-                  by keyboard and mouse</a>, performing the
-                same action, is available in the page</li>
-            </ul>
-          </li>
-          <li id="test-7-3-3"> Test 7.3.3: A <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            must not remove focus from an element that receives it.
-            Has this rule been followed (except
-              in <a title="Particular cases for criterion 7.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-3">particular cases</a>)?</li>
-          <li id="test-7-3-4"> Test 7.3.4: Does each interface
-            component implemented via a role defined by the ARIA
-            API, and matching a Design Pattern, meet one of the
-            following conditions?
-            <ul>
-              <li> The keyboard interactions comply with the Design
-                Pattern for the Esc, Space bar, Tab, and arrow keys,
-                at least</li>
-              <li> An interface component available in the page,
-                performing the same action, has keyboard
-                interactions complying with the Design Pattern for
-                the Esc, Space bar, Tab, and arrow keys, at least</li>
-              <li>An alternative providing access to the same
-                functionalities can be controlled by the keyboard
-                and the mouse.</li>
-            </ul>
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit7-3">technical note about keyboard interactions in the ARIA API</a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.3.1 - 2.1.1 - 2.1.3 - 2.4.7</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G202 - SCR2 - SCR20 -
-            SCR29 - SCR35 - G90 - F42 - F54 - F55</p>
-
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-7-4">Criterion 7.4 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-          that initiates a <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangContexte">change
-            of context</a>, is the user warned or can he control it?</h3>
-        <ul>
-          <li id="test-7-4-1"> Test 7.4.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            initiating a <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangContexte">change
-              of context</a> meet one of the following conditions?
-            <ul>
-              <li> The user is warned by a text about the <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-                action and the kind of change before it is activated</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangContexte">change
-                  of context</a> is initiated by an explicit button
-                (<code>input</code> tag of type submit,
-                  button or image, or <code>button</code> tag) </li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangContexte">change
-                  of context</a> is initiated by an explicit link</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            3.2.1 - 3.2.2 - 3.2.5</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): F9 - F22 - F36 - F37 - F41
-            - F76 - G13 - G76 - G80 - G107 - H32 - H84 - SCR19</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-7-5">Criterion 7.5 [AAA] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-          causing an unrequested <a href="./RGAA3.0_Glossary_English_version_v1.html#mAlerte">alert</a>
-          be controlled by the user (except in <a title="Particular cases for criterion 7.5"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-5">particular
-            cases</a>)?</h3>
-        <ul>
-          <li id="test-7-5-1">Test 7.5.1: Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            causing an unrequested <a href="./RGAA3.0_Glossary_English_version_v1.html#mAlerte">alert</a>
-            be controlled by the user (except in <a title="Particular cases for criterion 7.5"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-5">particular
-              cases</a>)? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.2.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): SCR14</p>
-      </article>
-        <ul class="navTheme">
-        <li class="haut"><a href="#toc">Table of contents</a></li>
-          <li class="haut"><a href="#script">Go to category: Scripts</a></li>
-          <li class="bas"><a href="#structure">Go to category: Information
-                structure
-             </a></li>
-        </ul>
-      <article id="elements" class="thematique">
-        <header>
-        <h2>Mandatory elements</h2>
-          <h3>General guidelines</h3>
-          <p>Check that each Web page has a valid source code
-            according to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
-              type</a>, a relevant title and a <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
-              default human language</a> identification. Check that
-            tags are not used for presentation only, that changes in
-            human language and changes in the direction of reading
-            order are specified.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-1">Criterion 8.1 [A] Is each Web page defined
-          by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
-            type</a>?</h3>
-        <ul>
-          <li id="test-8-1-1"> Test 8.1.1: For each Web page, is the
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
-              type</a> (doctype tag) available?</li>
-          <li id="test-8-1-2"> Test 8.1.2: For each Web page is the
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
-              type</a> (doctype tag) valid?</li>
-          <li id="test-8-1-3"> Test 8.1.3: For each Web page with a
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
-              type</a> declaration, is this declaration located
-            before the HTML tag in the source code?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            4.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G134 - G192</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-2">Criterion 8.2 [A] For each Web page, is
-          the source code <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeValide">valid</a>
-          according to the specified <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
-            type</a> (except in <a title="Particular cases for criterion 8.2" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-2">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-8-2-1"> Test 8.2.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
-              type</a> declaration, does the page source code meet
-            the following conditions (except in <a title="Particular cases for criterion 8.2" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-2">particular cases</a>)?
-            <ul>
-              <li> Tags follow the writing rules</li>
-              <li> Tag nesting is conform</li>
-              <li> Tag opening and closing are conform</li>
-              <li> Attributes follow the writing rules</li>
-              <li> The attribute values follow the writing rules</li>
-            </ul>
-          </li>
-          <li id="test-8.2.2"> Test 8.2.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
-              type</a> declaration, the page source code must not
-            contain obsolete elements. Has this rule been
-            followed (except in <a title="Particular cases for criterion 8.2" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-2">particular cases</a>)?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            4.1.1 - 4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G134 - G192 - H74 - H75 -
-            H88 - H93 - H94 - F70 - F77 - F62</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-3">Criterion 8.3 [A] On each Web page, is the
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
-            default human language</a> identifiable?</h3>
-        <ul>
-          <li id="test-8-3-1"> Test 8.3.1: For each Web page, does
-            the <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
-              default human language</a> identification meet one of
-            the following conditions?
-            <ul>
-              <li> The human language identification (<code>lang</code> and/or
-                <code>xml:lang</code> attribute) for the page is provided via the
-                HTML element</li>
-              <li> The human language identification (<code>lang</code> and/or
-                <code>xml:lang</code> attribute) for the page is provided via
-                each text element or one of the parent elements</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H57</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-4">Criterion 8.4 [A] For each Web page with a
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
-            default human language</a>, is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeLangue">
-            language code</a> appropriate?</h3>
-        <ul>
-          <li id="test-8-4-1"> Test 8.4.1: For each Web page with a
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
-              default human language</a>, does the <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeLangue">
-              language code</a> meet the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeLangue">language
-                  code</a> is valid</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeLangue">language
-                  code</a> is appropriate</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H57</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-5">Criterion 8.5 [A] Does each Web page have
-          a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitrePage">page
-            title</a>?</h3>
-        <ul>
-          <li id="test-8-5-1"> Test 8.5.1: Does each Web page have a
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitrePage">page
-              title</a> (<code>title</code> tag)?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G88 - G127 - H25</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-6">Criterion 8.6 [A] For each Web page with a
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitrePage">page
-            title</a>, is this title relevant?</h3>
-        <ul>
-          <li id="test-8-6-1"> Test 8.6.1: For each Web page with a
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitrePage">page
-              title</a> (<code>title</code> tag), is the content of this tag
-            relevant? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s):G88 - G127 - F25</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-7">Criterion 8.7 [AA] On each Web page, is
-          each change in the human language identified via the
-          source code (except
-            in <a title="Particular cases for criterion 8.7" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-7">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-8-7-1"> Test 8.7.1: On each Web page, does
-            each text written in a language differing from the <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
-              default human language</a> meet one of the following
-            conditions (except
-              in <a title="Particular cases for criterion 8.7" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-7">particular cases</a>)?
-            <ul>
-              <li> The human language identification is provided via
-                the element containing the text</li>
-              <li> The human language identification is provided via
-                one of the parent elements</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H58</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-8">Criterion 8.8 [AA] On each Web page, is
-          each change in human language relevant?</h3>
-        <ul>
-          <li id="test-8-8-1"> Test8.8.1: On each Web page, is each
-            change in human language identification (lang and/or
-            xml:lang attribute) technically valid?</li>
-          <li id="test-8-8-2"> Test 8.8.2: On each Web page, is each
-            change in human language identification (lang and/or
-            xml:lang attribute) relevant?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H58</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-9">Criterion 8.9 [A] On each Web page, tags
-          must not be used <a href="./RGAA3.0_Glossary_English_version_v1.html#mUniquPres">only
-            for layout</a>. Has this rule been followed?</h3>
-        <ul>
-          <li id="test-8-9-1"> Test 8.9.1: On each Web page, tags
-            must not be used (except <code>div</code>, <code>span</code> and <code>table</code>) <a href="./RGAA3.0_Glossary_English_version_v1.html#mUniquPres">only
-              for layout</a>. Has this rule been followed? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G115 - H88 - F43 - F92</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-8-10">Criterion 8.10 [A] On each Web page, are
-          changes in <a href="./RGAA3.0_Glossary_English_version_v1.html#mSensLecture">reading
-            direction</a> identified?</h3>
-        <ul>
-          <li id="test-8-10-1"> Test 8.10.1: On each Web page, does
-            each text for which the reading direction is different
-            from the default <a href="./RGAA3.0_Glossary_English_version_v1.html#mSensLecture">reading
-              direction</a> meet the following conditions?
-            <ul>
-              <li> the text is contained in an element with a <code>dir</code>
-                attribute</li>
-              <li> The value of the <code>dir</code> attribute is valid (<code>rtl</code> or
-                <code>ltr</code>)</li>
-              <li> The value of the <code>dir</code> attribute is relevant</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H56</p>
-      </article>
-        <ul class="navTheme">
-         <li class="haut"><a href="#toc">Table of contents</a></li>
-          <li class="haut"><a href="#elements">Go to category: Mandatory
-                elements</a></li>
-          <li class="bas"><a href="#presentation">Go to category: Presentation
-                of information</a></li>
-        </ul>
-      <article id="structure" class="thematique">
-        <header>
-        <h2>Information structure</h2>
-          <h3>General guidelines</h3>
-          <p>Use <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">headings</a>,
-            landmarks, lists, abbreviations and quotes to structure
-            information. </p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-9-1">Criterion 9.1 [A] On each Web page, is
-          information structured by the appropriate use of <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">headings</a>?</h3>
-        <ul>
-          <li id="test-9-1-1"> Test 9.1.1: Is there a level 1 <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">heading</a>
-            (<code>h1</code> tag or a tag with an ARIA
-              <code>role="heading"</code> associated to an <code>aria-level="1"</code>
-              property) on each Web page?</li>
-          <li id="test-9-1-2"> Test 9.1.2: On each Web page, is the
-            hierarchy between the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">headings</a>
-            (<code>h1</code> to <code>h6</code> tags or tags with an ARIA
-              <code>role="heading"</code> associated to an <code>aria-level</code> property)
-            relevant?</li>
-          <li id="test-9-1-3">Test 9.1.3: On each Web page, when a
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">heading</a>
-            (<code>h1</code> to <code>h6</code> tag or a tag with an ARIA
-              <code>role="heading"</code> associated to an <code>aria-level</code> property),
-             is necessary to structure information, is this heading available?</li>
-          <li id="test-9-1-4"> Test 9.1.4: On each Web page, is each
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">heading</a>
-            (<code>h1</code> to <code>h6</code> tag or a tag with an ARIA
-              <code>role="heading"</code> associated to an <code>aria-level</code> property)
-            relevant?</li>
-        </ul>
-
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-1">technical note about the ARIA <code>heading</code> role and <code>h1</code> headings</a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.3.1 - 2.4.1 - 2.4.6 - 2.4.10</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H69 - G115 - G130 - H42 -
-            G141 - ARIA4 - ARIA12</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-9-2">Criterion 9.2 [A] On each Web page, is the
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mDocumentOutline">document outline</a> coherent?</h3>
-        <ul>
-          <li id="test-9-2-1"> Test 9.2.1: On each Web page, does
-            the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDocumentOutline">document outline</a> meet the following conditions?
-            <ul>
-              <li>the <a href="./RGAA3.0_Glossary_English_version_v1.html#PageHeader">page header</a> is identified
-                via a <code>header</code> tag</li>
-              <li>the main and secondary <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation areas</a> are identified via a <code>nav</code> tag</li>
-              <li>the <code>nav</code> tag is used only to identify
-                the main and secondary <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation areas</a></li>
-              <li>the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> is identified
-                via a <code>main</code> tag</li>
-              <li>the <code>main</code> tag is unique in the page</li>
-              <li>the page <a href="./RGAA3.0_Glossary_English_version_v1.html#mFooter">footer</a> area is identified
-                via a <code>footer</code> tag</li>
-            </ul>
-          </li>
-          <li id="test-9-2-2"> Test 9.2.2: On each Web page, is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDocumentOutline">document outline</a> coherent?</li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-2">technical note about the document outline</a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G115 - ARIA11</p>
-
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-9-3">Criterion 9.3 [A] On each Web page, is
-          each <a href="./RGAA3.0_Glossary_English_version_v1.html#mListes">list</a>
-          structured  appropriately?</h3>
-        <ul>
-          <li id="test-9-3-1"> Test 9.3.1: On each Web page, does
-            information grouped in an unordered <a href="./RGAA3.0_Glossary_English_version_v1.html#mListes">list</a>
-            meet one of the following conditions?
-            <ul>
-              <li>the list uses the <code>ul</code> and <code>li</code> tags</li>
-              <li>the list
-                  uses the ARIA roles <code>list</code> and <code>listitem</code></li>
-            </ul>
-          </li>
-          <li id="test-9-3-2"> Test 9.3.2: On each Web page, does
-            information grouped in ordered <a href="./RGAA3.0_Glossary_English_version_v1.html#mListes">lists</a>
-            meet one of the following conditions?
-            <ul>
-              <li>the list uses the <code>ol</code> and <code>li</code> tags</li>
-              <li>the list
-                  uses the ARIA roles <code>list</code> and <code>listitem</code>
-              </li>
-            </ul>
-          </li>
-          <li id="test-9-3-3"> Test 9.3.3: On each Web page, does
-            information grouped in definition <a href="./RGAA3.0_Glossary_English_version_v1.html#mListes">lists</a>
-            use the <code>dl</code> and <code>dt</code>/<code>dd</code> tags? </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-3">technical note about the <code>list</code> and <code>listitem</code> roles</a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G153 - G115 - H40 - H48 -
-            H97 - F2</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-9-4">Criterion 9.4
-          [AAA] On each Web page, does the first occurence of each <a
-
-            href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-          help to know its meaning?</h3>
-        <ul>
-          <li id="test-9-4-1"> Test 9.4.1:
-            On each Web page, does the first occurence of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-            meet one of the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-                is provided with its meaning as an adjacent link</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-                is implemented via a link referring to a page or a
-                location in the page, providing its meaning</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-                is included in a link with a <code>title</code> attribute
-                providing its meaning</li>
-              <li> The meaning of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-                is available in a glossary on the website</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-                is implemented via an <code>abbr</code> tag with a <code>title</code> attribute
-                providing its meaning</li>
-            </ul>
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-4">technical note about the ARIA role <code>definition</code></a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G55 - G70 - G97 - G102 -
-            H28</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-9-5">Criterion 9.5
-          [AAA] On each Web page, is the meaning of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-          relevant?</h3>
-        <ul>
-          <li id="test-9-5-1"> Test 9.5.1:
-            On each Web page, is the meaning of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
-            relevant?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G55 - G70 - G97 - G102 -
-            H28</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-9-6">Criterion 9.6
-          [A] On each Web page, is each quotation identified
-          properly?</h3>
-        <ul>
-          <li id="test-9-6-1"> Test 9.6.1:
-            On each Web page, does each short quotation use a <code>q</code> tag?</li>
-          <li id="test-9-6-2"> Test 9.6.2:
-            On each Web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBlocCite">long
-              quotation</a> use a <code>blockquote</code> tag?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G115 - H49 - F2</p>
-      </article>
-        <ul class="navTheme">
-         <li class="haut"><a href="#toc">Table of contents</a></li>
-        <li class="haut"><a href="#structure">Go to category: Information structure</a></li>
-        <li class="bas"><a href="#formulaire">Go to category: Forms</a></li>
-        </ul>
-      <article id="presentation" class="thematique">
-        <header>
-        <h2>Presentation of information </h2>
-          <h3>General guidelines</h3>
-          <p>Use <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
-              sheets</a> to control information presentation. Check
-            for the effect of font size increasing on readability.
-            Ensure that links can be correctly identified, that
-            focus is specified, that line spacing is suffiscient,
-            and give the user the ability to control text
-            justification. Ensure that hidden texts are rendered
-            properly and that information is not conveyed only by an
-            element's shape, size or location.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-1">Criterion 10.1 [A] In the <a href="./RGAA3.0_Glossary_English_version_v1.html#mSiteWeb">Web
-            site</a>, are <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
-            sheets</a> used to control <a href="./RGAA3.0_Glossary_English_version_v1.html#mPresInfo">information
-            presentation</a>?</h3>
-        <ul>
-          <li id="test-10-1-1"> Test 10.1.1: On each Web page, tags
-            used for <a href="./RGAA3.0_Glossary_English_version_v1.html#mPresInfo">information
-              presentation</a> must not be available in the source
-            code. Has this rule been followed?</li>
-          <li id="test-10-1-2"> Test 10.1.2: On each Web page,
-            attributes used for <a href="./RGAA3.0_Glossary_English_version_v1.html#mPresInfo">information
-              presentation</a> must not be available in the source
-            code. Has this rule been followed?</li>
-          <li id="test-10-1-3"> Test 10.1.3: On each Web page, does
-            the use of white spaces meet the following conditions?
-            <ul>
-              <li>White spaces characters are not used to control spacing within a
-                word</li>
-              <li>White spaces characters are not used to format tables in plain text content</li>
-              <li>White spaces characters are not used to create multiple columns in plain text content</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.3.1 - 1.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G140 - F32 - F33 - F34 -
-            C6 - C8 - C18 - C22 - F48</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-2">Criterion 10.2 [A] On each Web page, is <a
-            href="./RGAA3.0_Glossary_English_version_v1.html#mVisibleContent">visible
-            content</a> still available when <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
-            sheets</a> or images are disabled?</h3>
-        <ul>
-          <li id="test-10-2-1"> Test 10.2.1: On each Web page, is
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mVisibleContent">visible content</a> still available when <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
-              sheets</a> are disabled?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.1.1 - 1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G140 - F3 - F87</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-3">Criterion 10.3 [A] On each Web page, is
-          information still <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">understandable</a>
-          when <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
-            sheets</a> are disabled?</h3>
-        <ul>
-          <li id="test-10-3-1">Test 10.3.1: On each Web page, is
-            information still <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">understandable</a>
-            when <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
-              sheets</a> are disabled?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.3.2 - 2.4.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): F1 - G59</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-4">Criterion 10.4 [AA] On each Web page, is
-          text still readable when <a href="./RGAA3.0_Glossary_English_version_v1.html#mTailleCaractere">character
-            size</a> is increased until at least 200%?</h3>
-        <ul>
-          <li id="test-10-4-1"> Test 10.4.1: In the <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
-              sheets</a> of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mSiteWeb">website</a>,
-            non relative units (pt, pc, mm, cm, in) must not be used
-            for the media types screen, tv, handheld, projection.
-            Has this rule been followed?</li>
-          <li id="test-10-4-2"> Test 10.4.2: In the <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
-              sheets</a> of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mSiteWeb">website</a>,
-            for the media types screen,
-              tv, handheld, projection, do font sizes use
-            relative units only?</li>
-          <li id="test-10-4-3"> Test 10.4.3: On each Web page,
-            increasing the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTailleCaractere">character
-              size</a> up to 200% must not cause loss of
-            information. Has this rule been followed? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.4.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G146 - F80 - F69 - C14 -
-            C12 - C13 - C17 - C28 - G179 - SCR34</lp>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-5">Criterion 10.5 [AA] On each Web page, are
-          CSS declarations for background and foreground colors
-          appropriate?</h3>
-        <ul>
-          <li id="test-10-5-1"> Test 10.5.1: On each Web page, for
-            each element that may contain text, is the CSS
-            declaration for foreground color accompanied by a
-            background color declaration at least, inherited from a
-            parent element?</li>
-          <li id="test-10-5-2"> Test 10.5.2: On each Web page, for
-            each element that may contain text, is the CSS
-            declaration for background color accompanied by a
-            foreground color declaration at least, inherited from a
-            parent element?</li>
-          <li id="test-10-5-3"> Test 10.5.3: On each Web page, for
-            each element that may contain text, if an image is used
-            to provide a background color via CSS, is there a
-            corresponding background color declaration, at least,
-            inherited from a parent element? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.4.3 - 1.4.6 - 1.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): F24</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-6">Criterion 10.6 [A] On each Web page, can
-          each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienNature">link
-            whose nature is not obvious</a> be distinguished from
-          the surrounding text?</h3>
-        <ul>
-          <li id="test-10-6-1"> Test 10.6.1: On each Web page, does
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienTexte">text
-              link</a> indicated through color alone, and whose nature is
-            not obvious, have a contrast ratio of 3:1 or greater
-            with the surrounding text? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.4.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G183 - F73</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-7">Criterion 10.7 [A] On each Web page, is
-          the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPriseFocus">focus
-           </a> visible for each element that receives focus?</h3>
-        <ul>
-          <li id="test-10-7-1">Test 10.7.1: For each element
-            receiving focus, the browser default visual cue must not
-            be removed (CSS property outline, outline-color,
-            outline-width, outline-style). Has this rule been
-            followed? </li>
-          <li id="test-10-7-2"> Test 10.7.2: For each element
-            receiving focus, the browser default visual cue must not
-            be degraded (CSS property outline-color). Has this rule
-            been followed?</li>
-          <li id="test-10.7.3"> Test 10.7.3: Does each link inside a
-            text, indicated through color alone, meet the conditions
-            below?
-            <ul>
-              <li>An additional visual cue, other than color, is
-                provided when the user tabs to the link with the
-                keyboard</li>
-              <li>An additional visual cue, other than color, is
-                provided when the user points to the link (hovers)
-                with the mouse</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.4.1 - 2.4.7</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G149 - G183 - F73 - F78 -
-            G165 - C15 - G195 - SCR31</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-8">Criterion 10.8 [AAA] On each Web page,
-          can the user specify the background and foreground colors?</h3>
-        <ul>
-          <li id="test-10-8-1"> Test 10.8.1: For each block of text
-            inside an HTML element, can the background color be
-            specified by the user?</li>
-          <li id="test-10-8-2"> Test 10.8.2: For each block of text
-            inside an HTML element, can the foreground color be
-            specified by the user?</li>
-          <li id="test-10-8-3"> Test 10.8.3: For each block of text
-            inside an <code>object</code>, embed, <code>svg</code>
-              or <code>canvas</code> tag, can the background color be
-            specified by the user?</li>
-          <li id="test-10-8-4"> Test 10.8.4: For each block of text
-            inside an <code>object</code>, embed, <code>svg</code>
-              or <code>canvas</code> tag, can the foreground color be
-            specified by the user? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G156 - G175</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-9">Criterion 10.9 [AAA] for each Web page,
-          text must not be fully justified. Has this rule been followed?</h3>
-        <ul>
-          <li id="test-10-9-1"> Test 10.9.1: Does each Web page meet
-            one of the following conditions?
-            <ul>
-              <li>The text is not fully justified</li>
-              <li>The user can remove the
-                full justification of text, via a provided mechanism</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): F88 - G166 - G172</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-10">Criterion 10.10 [AAA] For each Web page,
-          on a full-screen window and with a font size of 200%, is
-          each block of text still readable without the use of
-          horizontal scrolling?</h3>
-        <ul>
-          <li id="test-10-10-1"> Test 10.10.1: On each Web page,
-            does increasing the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTailleCaractere">text
-              size</a> up to 200% meet one of the following
-            conditions?
-            <ul>
-              <li> In a full-screen window, the use of horizontal
-                scrolling is not required to read a block of text</li>
-              <li>The user can display, via a provided mechanism, a version of the content where the use of horizontal
-                scrolling is not required to read a block of text, in a
-                full-screen window</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G146 - G206 - C19 - C24 -
-            C28</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-11">Criterion 10.11 [AAA] For each Web page,
-          is the length of lines of text equal to 80 characters or
-          less (except in <a title="Particular cases for criterion 10.11" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit10-11">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-10-11-1"> Test 10.11.1: For each Web page,
-            does each line of text meet one of the following
-            conditions (except in <a title="Particular cases for criterion 10.11"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit10-11">particular cases</a>)?
-            <ul>
-              <li> The length of each line of text is equal to 80
-                characters or less</li>
-              <li> The user can reduce the length of each line of
-                text, down to 80 characters or less, when resizing
-                the browser window</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G204 - C20</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-12">Criterion 10.12 [AAA] For each Web page,
-          is line and paragraph spacing sufficient?</h3>
-        <ul>
-          <li id="test-10-12-1"> Test 10.12.1: For each Web page,
-            does each block of text meet one of the following
-            conditions?
-            <ul>
-              <li> The line spacing is 1.5 times the text size, or
-                more</li>
-              <li> The user can increase the line spacing
-                to at least 1.5 times the text size, via a provided mechanism</li>
-            </ul>
-          </li>
-          <li id="test-10-12-2"> Test 10.12.2: For each Web page,
-            does each block of text meet one of the following
-            conditions?
-            <ul>
-              <li> The spacing between two paragraphs is 1.5 times
-                the line spacing, or more</li>
-              <li>The user can increase the spacing between two paragraphs
-                to at least 1.5 times the line spacing, via a provided mechanism</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G188 - C21</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-13">Criterion 10.13 [A] For each Web page,
-          are <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
-            texts</a> rendered properly by assistive technologies?</h3>
-        <ul>
-          <li id="test-10-13-1">Test 10.13.1: On each Web page, does
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
-              text</a> meet one of the following conditions?
-            <ul>
-              <li>The text is not intended to be rendered by
-                assistive technologies</li>
-              <li> The text is made visible on user action on the
-                element itself or on an element before the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
-                  text</a></li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
-                    text</a> is part of a user interface
-                component ruled by the ARIA API, which manages the
-                displayed or hidden status of the content</li>
-            </ul>
-          </li>
-          <li id="test-10-13-2">Test
-              10.13.2: On each Web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
-                text</a> using an ARIA property <code>aria-hidden</code> meet one
-              of the following conditions?
-            <ul>
-              <li>The text is not intended
-                  to be rendered by assistive technologies</li>
-              <li>The value of the ARIA
-                  property <code>aria-hidden</code> matches the visible or hidden
-                  status of the text
-                </li>
-            </ul>
-          </li>
-          <li id="test-10-13-3">Test
-              10.13.3: On each Web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
-                text</a> using the <code>hidden</code> attribute  meet one of the
-              following conditions?
-            <ul>
-
-              <li>The text is not intended
-                  to be rendered by assistive technologies</li>
-
-              <li> The text is made
-                  visible on user action on the element itself or on
-                  an element before the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
-                    text</a></li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
-                    text</a> is part
-                  of a user interface component ruled by the ARIA
-                  API, which manages the displayed or hidden status
-                  of the content</li>
-            </ul>
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit10-13">technical note about the <code>aria-hidden</code> property and the <code>hidden</code> attribute</a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            4.1.2 - 1.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G57</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-14">Criterion 10.14 [A] On each Web page,
-          information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been followed?</h3>
-        <ul>
-          <li id="test-10-14-1"> Test 10.14.1: On each Web page, for
-            each text or set of text, information must not be
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule
-            been followed?</li>
-          <li id="test-10-14-2"> Test 10.14.2: On each Web page, for
-            each image or set of images, information must not be
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule
-            been followed?</li>
-          <li id="test-10-14-3"> Test 10.14.3: On each Web page, for
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a>, information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been followed?</li>
-          <li id="test-10-14-4"> Test 10.14.4: On each Web page, for
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-              time-based media</a>, information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been
-            followed?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.4.1 - 1.3.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G96 - G111 - G140 - F14 -
-            F26</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-10-15">Criterion 10.15 [A] On each Web page,
-          information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been implemented in a
-          relevant way?</h3>
-        <ul>
-          <li id="test-10-15-1"> Test 10.15.1: On each Web page, for
-            each text or set of text, information must not be
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule
-            been implemented in a relevant way?</li>
-          <li id="test-10-15-2"> Test 10.15.2: On each Web page, for
-            each image or set of images, information must not be
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule
-            been implemented in a relevant way?</li>
-          <li id="test-10-15-3"> Test 10.15.3: On each Web page, for
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
-              media</a>, information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been implemented
-            in a relevant way?</li>
-          <li id="test-10-15-4"> Test 10.15.4: On each Web page, for
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
-              time-based media</a>, information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been
-            implemented in a relevant way?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.4.1 - 1.3.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G96 - G111 - G140 - F14 -
-            F26</p>
-      </article>
-       <ul class="navTheme">
-         <li class="haut"><a href="#toc">Table of contents</a></li>
-         <li class="haut"><a href="#presentation">Go to category: Presentation
-                of information</a></li>
-          <li class="bas"><a href="#navigation">Go to category: Navigation</a></li>
-        </ul>
-      <article id="formulaire" class="thematique">
-         <header>
-        <h2>Forms</h2>
-          <h3>General guidelines</h3>
-          <p>For each form, associate each control with its label,
-            group controls in similar blocks of information,
-            structure selection lists in a consistent way, give each
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mBtnForm">button</a>
-            an explicit label. Check that input help is available,
-            ensure that the <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleSaisie">input
-              control</a> is accessible and that the user can
-            control financial, legal or personal data.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-1">Criterion 11.1 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
-            field</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>?</h3>
-        <ul>
-          <li id="test-11-1-1"> Test 11.1.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
-              field</a> meet one of the following conditions?
-            <ul>
-              <li> The form field has a <code>title</code> attribute</li>
-              <li> A <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>
-                (<code>label</code> tag) is associated with the form field</li>
-              <li>The form field has an
-                  <code>aria-label</code> property</li>
-              <li>The form field has an
-                  <code>aria-labelledby</code> property that references an
-                  identified chunk of text</li>
-            </ul>
-          </li>
-          <li id="test-11-1-2">Test 11.1.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
-              field</a> that is associated with a label (<code>label</code> tag),
-            meet the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
-                  field</a> has an <code>id</code> attribute</li>
-              <li> The value of the <code>id</code> attribute is unique</li>
-              <li>The <code>label</code> tag has a for
-                  attribute</li>
-              <li>The value of the for
-                  attribute matches the value of the corresponding
-                  form field <code>id</code> attribute </li>
-            </ul>
-          </li>
-          <li id="test-11-1-3">Test
-              11.1.3: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
-                field</a> associated with a label, via the ARIA
-              <code>aria-labelledby</code> property, meet the following
-              conditions?
-            <ul>
-              <li> The label has an <code>id</code>
-                  attribute</li>
-              <li>The value of the <code>id</code>
-                  attribute is unique</li>
-              <li> The value of the ARIA
-                  <code>aria-labelledby</code> property matches the value of the
-                  label <code>id</code> attribute</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.3.1 - 2.4.6 - 3.3.2 - 4.1.2 </p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H44 - H65 - G82 - G131 -
-            ARIA6 - ARIA9 - ARIA16 - ARIA14 - F17 - F82 - F86 - F68</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-2">Criterion 11.2 [A] Is each label that is
-          associated with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
-            field</a> relevant?</h3>
-        <ul>
-          <li id="test-11-2-1"> Test 11.2.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>
-            (<code>label</code> tag) describe the exact function of the
-            associated <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
-              field</a>?</li>
-          <li id="test-11-2-2"> Test 11.2.2: Does each <code>title</code>
-            attribute describe the exact function of the
-            associated <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
-              field</a>? </li>
-          <li id="test-11-2-3"> Test 11.2.3: Does each label
-            implemented via the ARIA <code>aria-label</code> property describe the exact function of the associated <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form  field</a>? </li>
-          <li id="test-11-2-2"> Test 11.2.2: Does each label
-            implemented via the ARIA <code>aria-labelledby</code> property describe the exact function of the associated <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form field</a>?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            2.4.6 - 3.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H44 - H65 - G182 - G131 -
-            ARIA6 - ARIA9 - ARIA16 - ARIA14</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-3">
-          Criterion 11.3 [AA] On a given page, or set of pages, all form fields with similar functions must have consistent  <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">labels</a>. Has this rule been followed?</h3>
-        <ul>
-          <li id="test-11-3-1">
-            Test 11.3.1: On a given page, all form fields with similar functions must have consistent  <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">labels</a>. Has this rule been followed?
-          </li>
-
-          <li id="test-11-3-2">
-            Test 11.3.2: On a given set of pages, all form fields with similar functions must have consistent  <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">labels</a>. Has this rule been followed?
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-          <p>WCAG 2.0 success criterion: 3.2.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): F31</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-4">Criterion 11.4 [A] In each form, are each
-           <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>
-          and its related control positioned next to each other?</h3>
-        <ul>
-          <li id="test-11-4-1"> Test 11.4.1: In each form, are each
-             <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>
-            and its related control positioned next to each other?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G162</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-5">Criterion 11.5 [A] In each form, is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoMNature">information of same nature</a> grouped together, if necessary?</h3>
-        <ul>
-          <li id="test-11-5-1">Test 11.5.1: In each form, is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoMNature">information of same nature</a> grouped together via a <code>fieldset</code> tag, if necessary? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.3.1 - 3.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H71</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-6">Criterion 11.6 [A] In each form, does
-          each form field grouping have a legend?</h3>
-        <ul>
-          <li id="test-11-6-1"> Test 11.6.1: Is each form field
-            grouping (<code>fieldset</code> tag) followed by a legend (<code>legend</code>
-            tag) in the source code? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.3.1 - 3.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H71</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-7">Criterion 11.7 [A] In each form, is each
-          legend, related to a form field grouping, relevant?</h3>
-        <ul>
-          <li id="test-11-7-1"> Test 11.7.1: In each form, is each
-            legend (<code>legend</code> tag), related to a form field grouping
-            (<code>fieldset</code> tag), relevant? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H71</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-8">Criterion 11.8 [A] In each form, is each
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mListeChoix">selection
-            list</a> structured in a relevant way?</h3>
-        <ul>
-          <li id="test-11-8-1"> Test 11.8.1: In each form, are for
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mListeChoix">selection
-              list</a> (<code>select</code> tag) items grouped together with an
-            <code>optgroup</code> tag, if necessary?</li>
-          <li id="test-11-8-2"> Test 11.8.2: In each <a href="./RGAA3.0_Glossary_English_version_v1.html#mListeChoix">selection
-              list</a> (<code>select</code> tag), does each list item grouping
-            (<code>optgroup</code> tag) have a <code>label</code> attribute?</li>
-          <li id="test-11-8-3"> Test 11.8.3: For each list item
-            grouping (<code>optgroup</code> tag) with a <code>label</code> attribute, is the
-            content of the <code>label</code> attribute relevant?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H85</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-9">Criterion 11.9 [A] In each form, is the
-          text of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBtnForm">button</a>
-          relevant?</h3>
-        <ul>
-          <li id="test-11-9-1">Test 11.9.1: In each form, does the
-            text of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBtnForm">button</a>
-            meet one of the following conditions?
-            <ul>
-              <li> The content of the <code>value</code> attribute of the form
-                buttons of type <code>submit</code>, <code>reset</code> or <code>button</code> is relevant</li>
-              <li> The content of the <code>&lt;button&gt;</code> tag is relevant</li>
-              <li> The content of the <code>title</code>
-                  attribute is relevant</li>
-              <li>The content of the ARIA
-                  property <code>aria-label</code> is relevant</li>
-            </ul>
-          </li>
-          <li id="test-11-9-2">Test
-              11.9.2: In each form, does the text of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBtnForm">button</a>
-              implemented via an ARIA property <code>aria-labelledby</code> meet
-              the following conditions?
-            <ul>
-
-              <li> The referenced chunk of
-                  text has an <code>id</code> attribute</li>
-
-              <li> The value of the <code>id</code>
-                  attribute is unique</li>
 
-              <li> The value of the ARIA
-                  property <code>aria-labelledby</code> matches the value of the
-                  <code>id</code> attribute of the chunk of text</li>
-              <li>The chunk of text is
-                  relevant</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H36 - H91 - ARIA6 - ARIA9
-            - ARIA16 - ARIA14</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-10">Criterion 11.10 [A] In each form, is the
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleSaisie">input
-            control</a> used in a relevant way?</h3>
-          <ul>
-            <li id="test-11-10-1"> Test
-                11.10.1: For each form, do mandatory fields
-                indications meet one of the following conditions?
-              <ul>
-                <li>The
-                    mandatory field indication is provided via a chunk
-                    of text before the form field</li>
-                <li>The
-                    mandatory field indication is provided via a
-                    "<code>required</code>" attribute</li>
-                <li>The
-                    mandatory field indication is provided via an
-                    <code>aria-required</code> ARIA property</li>
-                <li>The
-                    mandatory field indication is provided via the label
-                    (<code>label</code> tag, or <code>title</code> attribute, or <code>aria-label</code>
-                    property, or labelling chunk of text identified via
-                    the <code>aria-labelledby</code> property) of the form field</li>
-                <li>The
-                    mandatory field indication is provided via a chunk
-                    of text, tied to the form field via the
-                    <code>aria-describedby</code> ARIA property</li>
-              </ul>
-           </li>
-
-          <li id="test-11-10-2"> Test
-              11.10.2: Each mandatory field indication based on the
-              ARIA properties <code>aria-label</code>, <code>aria-required</code>, or the
-              "<code>required</code>" attribute, must have an explicit visual cue
-              in its label (<code>label</code> tag) or in a chunk of text tied to
-              the form field via the ARIA property <code>aria-describedby</code>
-              or <code>aria-labelledby</code>. Has this rule been followed?</li>
-
-          <li id="test-11-10-3">Test
-              11.10.3: Does each mandatory field indication provided
-              via a chunk of text tied by an ARIA property
-              <code>aria-describedby</code> or <code>aria-labelledby</code> meet the following
-              conditions?
-            <ul>
-              <li> The referenced chunk of
-                  text has an <code>id</code> attribute</li>
-              <li> The value of the <code>id</code> attribute is unique</li>
-              <li> The value of the ARIA
-                  property <code>aria-describedby</code> or <code>aria-labelledby</code> matches
-                  the value of the <code>id</code> attribute
-                </li>
-            </ul>
-          </li>
-          <li id="test-11-10-4">Test
-              11.10.4: For each form, do the input errors meet one
-              of the following conditions?
-            <ul>
-              <li> The input error message
-                  is provided via the label (<code>label</code> tag, or <code>title</code>
-                  attribute, or <code>aria-label</code> property, or labelling
-                  chunk of text identified via the <code>aria-labelledby</code>
-                  property) of the form field</li>
-              <li>The input error message is
-                  provided via a chunk of text before the form field</li>
-              <li>The form field has a type
-                  that automatically generates an input error message</li>
-              <li>The input error message is
-                  provided via a chunk of text tied to the form field
-                  via the ARIA property <code>aria-describedby</code></li>
-              <li>The input error is
-                  signaled via the ARIA property <code>aria-invalid</code></li>
-            </ul>
-          </li>
-          <li id="test-11-10-5">Test 11.10.5: Each input
-              error indication based on the ARIA properties
-              <code>aria-label</code> or <code>aria-invalid</code> must have an explicit
-              visual cue in the label (<code>label</code> tag) or in a chunk of
-              text tied to the form field via the ARIA property
-              <code>aria-describedby</code> or <code>aria-labelledby</code>. Has this rule
-              been followed?
-          </li>
-          <li id="test-11-10-6">Test
-              11.10.6: Does each input error indication provided via
-              a chunk of text tied by an ARIA property
-              <code>aria-describedby</code> or <code>aria-labelledby</code> meet the following
-              conditions?
-            <ul>
-              <li> The referenced chunk of
-                  text has an <code>id</code> attribute</li>
-              <li> The value of the <code>id</code>
-                  attribute is unique</li>
-              <li> The value of the ARIA
-                  property <code>aria-describedby</code> or <code>aria-labelledby</code> matches
-                  the value of the <code>id</code> attribute</li>
-            </ul>
-          </li>
-          <li id="test-11-10-7"> Test
-              11.10.7: For each form, does each mandatory field meet
-              one of the following conditions?
-            <ul>
-              <li>The data
-                  type and/or format is provided, if necessary, via
-                  the field label (<code>label</code> tag, or <code>title</code> attribute, or
-                  <code>aria-label</code> property, or labelling chunk of text
-                  identified via the <code>aria-labelledby</code> property)</li>
-              <li>The data
-                  type and/or format is provided, if necessary, via a
-                  chunk of text before the form field </li>
-              <li>The data
-                  type and/or format is provided via a chunk of text,
-                  tied to the form field via the <code>aria-describedby</code> ARIA
-                  property</li>
-            </ul>
-          </li>
-          <li id="test-11-10-8"> Test
-              11.10.8: Each data type and/or format indication based
-              on the ARIA properties <code>aria-label</code> must have an
-              explicit visual cue in its label (<code>label</code> tag) or in a
-              chunk of text tied to the form field via the ARIA
-              property <code>aria-describedby</code> or <code>aria-labelledby</code>. Has this
-              rule been followed?</li>
-          <li id="test-11-10-9">Test
-              11.10.9: Does each data type and/or format indication
-              provided via a chunk of text tied by an ARIA property
-              <code>aria-describedby</code> or <code>aria-labelledby</code> meet the following
-              conditions?
-            <ul>
-              <li> The referenced chunk of
-                  text has an <code>id</code> attribute</li>
-              <li> The value of the <code>id</code>
-                  attribute is unique</li>
-              <li> The value of the ARIA
-                  property <code>aria-describedby</code> or <code>aria-labelledby</code> matches
-                  the value of the <code>id</code> attribute</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            3.3.1 - 3.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G83 - G84 - G85 - G89 -
-            G184 - H44 - H89 - H90 - F81 - SCR18 - SCR32 - ARIA1 -
-            ARIA2 - ARIA6 - ARIA9 - ARIA16 - ARIA21</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-11">Criterion 11.11 [AA] In each form, is <a
-
-            href="./RGAA3.0_Glossary_English_version_v1.html#mControleSaisie">input
-            control</a> accompanied, if necessary,
-          by suggestions helping with the correction of input
-          errors?</h3>
-        <ul>
-          <li id="test-11-11-1"> Test 11.11.1: For each form, for
-            each input error, are each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTypeDonnes">data
-              types and formats</a> suggested, if necessary?</li>
-          <li id="test-11-11-2"> Test 11.11.2: For each form, for
-            each input error, are examples for expected values
-            suggested, if necessary?
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit11-11">technical note about automatic format controls in HTML5</a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.3.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G84 - G85 - G89 - G177 -
-            H89</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-12">Criterion 11.12 [AA] For each form, can
-          financial, legal or personal data be changed, updated or
-          retrieved by the user?</h3>
-        <ul>
-          <li id="test-11-12-1"> Test 11.12.1: For each form, do the
-            input of financial, legal or personal data meet one of
-            the following conditions?
-            <ul>
-              <li> The user can change or reset the data, and cancel
-                actions made on these data after they have been
-                entered</li>
-              <li> The user can check and modify data before form
-                submission</li>
-              <li> An explicit confirmation mechanism, via a form
-                field or an additional step, is available</li>
-            </ul>
-          </li>
-          <li id="test-11-12-2">Test 11.12.2: For each form, does
-            the deletion of financial, legal or personal data meet
-            one of the following conditions?
-            <ul>
-              <li> The user can recover data that have been
-                deleted, via a provided mechanism</li>
-              <li> An explicit mechanism confirming deletion, via a
-                form field or an additional step, is available </li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.3.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G98 - G99 - G155 - G164 -
-            G168</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-13">Criterion 11.13 [AAA] For each form, can
-          all data be changed, updated or recovered by the user?</h3>
-        <ul>
-          <li id="test-11-13-1"> Test 11.13.1: For each form, does
-            data input meet one of the following conditions?
-            <ul>
-              <li> The user can change or cancel data and actions on
-                this data after it has been entered</li>
-              <li> The user can check and correct data before form
-                submission</li>
-              <li> An explicit confirmation mechanism, via a form
-                field or an additional step, is available </li>
-            </ul>
-          </li>
-          <li id="test-11-13-2"> Test 11.13.2: For each form, does
-            data deletion meet one of the following conditions?
-            <ul>
-              <li> The user can recover data that have been
-                deleted, via a provided mechanism</li>
-              <li> An explicit mechanism confirming deletion, via a
-                form field or an additional step, is available </li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.3.6</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G98 - G99 - G155 - G164-
-            G168</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-14">Criterion 11.14 [AAA] For each form, is
-          input assistance available?</h3>
-        <ul>
-          <li id="test-11-14-1"> Test 11.14.1: Does each form meet
-            one of the following conditions?
-            <ul>
-              <li> There is a link to a help page</li>
-              <li>Indications before the form are available</li>
-              <li>Indications before form fields are available</li>
-              <li>Indications are provided
-                  via the form field label (<code>label</code> tag, or title
-                  attribute, or <code>aria-label</code> property, or labelling
-                  chunk of text identified via the <code>aria-labelledby</code>
-                  property)</li>
-              <li>Indications are provided
-                  via a chunk of text, tied to the form field via
-                  the <code>aria-describedby</code> ARIA property</li>
-              <li>an assistant is available</li>
-            </ul>
-          </li>
-          <li id="test-11-14-2">Test
-              11.14.2: Each indication based on the ARIA property
-              <code>aria-label</code> must have an explicit visual cue. Has this
-              rule been followed?</li>
-          <li id="test-11-14-3">Test
-              11.14.3: Does each indication provided via a chunk of
-              text tied by an ARIA property <code>aria-describedby</code> meet
-              the following conditions?
-            <ul>
-              <li> The referenced chunk of
-                  text has an <code>id</code> attribute</li>
-              <li> The value of the <code>id</code>
-                  attribute is unique</li>
-              <li> The value of the ARIA
-                  property <code>aria-describedby</code> matches the value of the <code>id</code>
-                  attribute</li>
-            </ul>
-          </li>
-          <li id="test-11-14-4">Test 11.14.4: Does each field of
-            type text meet one of the following conditions, if
-            necessary?
-            <ul>
-              <li> A spell checking tool is available</li>
-              <li>Input suggestions are
-                  provided before the form field</li>
-              <li>Input suggestions are
-                  provided via the form field label (<code>label</code> tag, or
-                  <code>title</code> attribute, or <code>aria-label</code> property, or
-                  labelling chunk of text identified via the
-                  <code>aria-labelledby</code> property)</li>
-              <li>Input
-                  suggestions are provided via a chunk of text, tied
-                  to the form field via the <code>aria-describedby</code> ARIA
-                  property</li>
-            </ul>
-          </li>
-
-          <li id="test-11-14-5">Test 11.14.5: Each input
-            suggestion based on the ARIA property <code>aria-label</code> must
-            have an explicit visual cue. Has this rule been
-            followed?</li>
-          <li id="test-11-14-6">Test
-              11.14.6: Does each input suggestion provided via a
-              chunk of text tied by an ARIA property
-              <code>aria-describedby</code> meet the following conditions?
-            <ul>
-              <li> The referenced chunk of
-                  text has an <code>id</code> attribute</li>
-              <li> The value of the <code>id</code>
-                  attribute is unique</li>
-              <li> The value of the ARIA
-                  property <code>aria-describedby</code> matches the value of the <code>id</code>
-                  attribute</li>
-            </ul>
-          </li>
-
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.3.5</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G71 - G193 - G194 - G184 -
-            G89 - ARIA1 - ARIA6 - ARIA9 - ARIA16 - F81</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-11-15">Criterion 11.15 [AAA] For each form, is
-          each input assistance relevant?</h3>
-        <ul>
-          <li id="test-11-15-1"> Test 11.15.1: For each form, is
-            each input assistance relevant?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.3.5</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G71 - G193 - G194 - G184 -
-            G89 - ARIA1 - ARIA9 - ARIA16 - F81</p>
-
-      </article>
-      <ul class="navTheme">
-        <li class="haut"><a href="#toc">Table of contents</a></li>
-      <li class="haut"><a href="#formulaire">Go to category: Forms</a></li>
-      <li class="bas"><a href="#consultation">Go to category: Consultation</a></li>
-      </ul>
-      <article id="navigation" class="thematique">
-        <header>
-        <h2>Navigation</h2>
-          <h3>General guidelines</h3>
-          <p>Facilitate navigation in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
-              of pages</a> through at least two different navigation
-            systems (<a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
-              menu</a>, site map or <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
-              engine</a>), breadcrumb trail and the indication of
-            the active page in the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation menu</a>. Identify groups
-            of important links and the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a>, and provide the
-            ability to avoid them through internal navigation links.
-            Ensure that tabbing order is consistent and that the
-            page does not contain keyboard traps.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-1">Criterion 12.1 [AA] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
-            of pages</a> have at least two different <a href="./RGAA3.0_Glossary_English_version_v1.html#mSysNav">navigation
-            systems</a> (except in <a title="Particular cases for criterion 12.1"  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-1">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-12-1-1"> Test 12.1.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
-              of pages</a> meet one of the following conditions (except in <a title="Particular cases for criterion 12.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-1">particular cases</a>)?
-            <ul>
-            <li> A <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation menu</a> and a site map are available</li>
-              <li> A <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
-                  menu</a> and a <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
-                  function</a> are available</li>
-              <li> A <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
-                  function</a> and a site map are available</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            2.4.5 - 2.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G63 - G64 - G161</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-2">Criterion 12.2 [AA] On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
-            of pages</a>, are the menu or the <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation
-            bars</a> always located at the same place (except in <a title="Particular cases for criterion 12.2"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-12-2-1"> Test 12.2.1: On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
-              of pages</a>, does each page with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
-              menu</a> meet the following conditions (except in <a title="Particular cases for criterion 12.2"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
-                  menu</a> is always located at the same place in
-                the presentation</li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
-                  menu</a> is always presented in the same relative
-                order in the source code.</li>
-            </ul>
-          </li>
-          <li id="test-12-2-2">Test 12.2.2 Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation
-              bar</a> that is repeated in a set of pages meet the
-            following conditions (except in <a title="Particular cases for criterion 12.2"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation
-                  bar</a> is always located at the same place in the
-                presentation </li>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation
-                  bar</a> is always presented in the same relative
-                order in the source code.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.2.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G61 - F66</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-3">Criterion 12.3 [AA] On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
-            of pages</a>, do the menu and the <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation bars</a> have a
-          consistent presentation (except in <a title="Particular cases for criterion 12.3"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-12-3-1"> Test 12.3.1: On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
-              of pages</a>, does the main <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
-              menu</a> have a consistent presentation (except in <a title="Particular cases for criterion 12.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?</li>
-          <li id="test-12-3-2"> Test 12.3.2: On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
-              of pages</a>, do repeated <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation bars</a> have a
-            consistent presentation (except in <a title="Particular cases for criterion 12.3"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.2.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G61</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-4">Criterion 12.4 [AA] Is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
-            map" page</a> relevant?</h3>
-        <ul>
-          <li id="test-12-4-1"> Test 12.4.1: Does the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
-              map" page</a> represent the site general
-            architecture?</li>
-          <li id="test-12-4-2"> Test 12.4.2: Are the links of the
-            site map functional?</li>
-          <li id="test-12-4-3"> Test 12.4.3: Do the links of the
-            site map refer to the pages that are specified by the
-            text?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            2.4.5 - 2.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G63</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-5">Criterion 12.5 [AA] In each set of pages,
-          is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
-            map" page</a> accessible in an identical way?</h3>
-        <ul>
-          <li id="test-12-5-1"> Test 12.5.1: In each set of pages,
-            is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
-              map" page</a> accessible from an identical
-            functionality?</li>
-          <li id="test-12-5-2"> Test 12.5.2: In each set of pages,
-            is the functionality leading to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
-              map" page</a> located at the same place in the
-            presentation?</li>
-          <li id="test-12-5-3"> Test 12.5.3: In each set of pages,
-            is the functionality leading to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
-              map" page</a> always presented in the same relative
-            order in the source code?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            2.4.5 - 2.4.8 - 3.2.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G61 - G63</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-6">Criterion 12.6 [AA] In each set of pages,
-          is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
-            function</a> accessible in an identical way?</h3>
-        <ul>
-          <li id="test-12-6-1"> Test 12.6.1: In each set of pages,
-            is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
-              function</a> accessible with an identical
-            functionality?</li>
-          <li id="test-12-6-2"> Test 12.6.2: In each set of pages,
-            is the functionality leading to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
-              function</a> located at the same place in the
-            presentation?</li>
-          <li id="test-12-6-3"> Test 12.6.3: In each set of pages,
-            is the functionality leading to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
-              function</a> always presented in the same relative
-            order in the source code?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.2.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G61 - F66</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-7">Criterion 12.7 [AA] On each page within a
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mCollecPage">collection
-            of pages</a>, are links facilitating navigation
-          available?</h3>
-        <ul>
-          <li id="test-12-7-1">Test 12.7.1: Does each page within a
-            <a href="./RGAA3.0_Glossary_English_version_v1.html#mCollecPage">collection
-              of pages</a>, meet the following conditions?
-            <ul>
-              <li>A link provides access to the next page</li>
-              <li>A link provides access to the previous page</li>
-              <li><a href="./RGAA3.0_Glossary_English_version_v1.html#mAccColl">Links
-                  provide access to each page</a> of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mCollecPage">collection
-                  of pages</a></li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            2.4.5 - 2.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G125 - G126 - G127 - G185</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-8">Criterion 12.8 [AAA] On each Web page, is a
-          breadcrumb trail available (except in <a title="Particular cases for criterion 12.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-8">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-12-8-1">Test 12.8.1: On each web page, is a breadcrumb trail
-            available (except in <a title="Particular cases for criterion 12.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-8">particular cases</a>)?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G65</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-9">Criterion 12.9 [AAA] On each Web page, is
-          the breadcrumb trail relevant?</h3>
-        <ul>
-          <li id="test-12-9-1"> Test 12.9.1: On each Web page, does
-            the breadcrumb trail represents the page position in the
-            site structure? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G65</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-10">Criterion 12.10 [A] On each Web page,
-          are groups of important links (menu, navigation bar&hellip;)
-          and the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> identified (except in <a title="Particular cases for criterion 12.10" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-10">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-12-10-1">Test 12.10.1: On each Web page, is
-            each group of important links implemented in a single tag?</li>
-          <li id="test-12-10-2">Test 12.10.2: On each Web page, does
-            each group of important links meet one of the following
-            conditions?
-            <ul>
-              <li> The element that structures the group of
-                important links has an <code>id</code> attribute</li>
-              <li> The element that structures the group of
-                important links is immediately preceeded, in the
-                source code, with a named  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a></li>
-              <li> the first link in the group is immediately
-                preceeded, in the source code, with a named  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a></li>
-            </ul>
-          </li>
-          <li id="test-12-10-3"> Test 12.10.3: On each Web page,
-            does the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> meet one of the following
-            conditions?
-           <ul>
-            <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> has an <code>id</code> attribute</li>
-            <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> is immediately preceeded, in the
-              source code, with a named  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a></li>
-            <li> the first element of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> is
-              immediately preceeded, in the source code, with a
-              named  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a></li>
-           </ul>
-          </li>
-          <li id="test-12-10-4">Test
-              12.10.4: On each Web page, does the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDocumentOutline">document outline</a>
-              meet the following conditions?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#PageHeader">page header</a>
-                  has an ARIA <code>role="banner"</code></li>
-              <li>The main <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation menu</a>
-                  has an ARIA <code>role="navigation"</code></li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a>
-                  has an ARIA <code>role="main"</code></li>
-              <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mFooter">footer</a> of the page
-                  has an ARIA <code>role="contentinfo"</code></li>
-              <li>The main <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation menu</a>
-                  has an ARIA <code>role="navigation"</code></li>
-              <li> The website <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search engine</a> has an ARIA <code>role="search"</code></li>
-              <li>The ARIA roles <code>banner</code>,
-                  <code>main</code>, <code>contentinfo</code>, and <code>search</code> are unique in the
-                  page</li>
-              <li>The ARIA role <code>navigation</code>
-                  is used only for the main and secondary <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation areas</a></li>
-            </ul>
-          </li>
-        </ul>
-        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit12-10">technical note about the landmark roles and skiplinks</a>.
-        </p>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.3.1 - 2.4.1 - 4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G115 - H50 - ARIA4 -
-            ARIA11</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-11">Criterion 12.11 [A] On each Web page,
-          are <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienEvitement">bypass
-            or skip links</a> to groups of important links
-          and to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> available (except in <a title="Particular cases for criterion 12.11" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-11">particular cases</a>)</h3>
-        <ul>
-          <li id="test-12-11-1"> Test 12.11.1: On each Web page,
-            is there a link to bypass, or skip to, each identified group of
-            important links?</li>
-          <li id="test-12-11-2"> Test 12.11.2: On each Web page,
-            is there a link to bypass, or skip to, the identified content area
-            or to access it?</li>
-          <li id="test-12-11-3"> Test 12.11.3: On each Web page,
-            is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienEvitement">bypass
-              or skip link</a> functional?</li>
-          <li id="test-12-11-4"> Test 12.11.4: On each set of pages,
-            do <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienEvitement">bypass
-              or skip links</a> meet the following
-            conditions?
-            <ul>
-              <li> Each link is located at the same place in the
-                layout</li>
-              <li> Each link is always presented in the same
-                relative order in the source code</li>
-              <li>Each link is visible at least on focus</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            2.4.1 - 2.4.3 - 3.2.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G1 - G59 - G123 - G124 -
-            SCR28 - F66</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-12">Criterion 12.12 [AAA] On each Web page,
-          is the current  page specified in the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
-            menu</a>?</h3>
-        <ul>
-          <li id="test-12-12-1">Test 12.12.1: On each Web page, is
-            the current  page specified in the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
-              menu</a>?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.8</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G128</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-13">Criterion 12.13 [A] On each Web page, is
-          <a href="./RGAA3.0_Glossary_English_version_v1.html#mOrdTab">tabbing
-            order</a> <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">consistent</a>?</h3>
-        <ul>
-          <li id="test-12-13-1"> Test 12.13.1: On each Web page, is
-            the tabbing order through the content <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">consistent</a>
-           ?</li>
-          <li id="test-12-13-2"> Test 12.13.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            that updates or inserts content, does tabbing order
-            remain <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">consistent</a>?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G59 - H4 - F44 - SCR26 -
-            SCR27 - SCR37 - C27 - F85</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-12-14">Criterion 12.14 [A] On each Web page,
-          navigation must not contain keyboard trap. Has this rule
-          been followed?</h3>
-        <ul>
-          <li id="test-12-14-1">Test 12.14.1: On each Web page, does
-            each element that receives focus meet one of the
-            following conditions?
-            <ul>
-              <li> It is possible to reach the next or previous
-                element that can receive focus with the tab key</li>
-              <li> The user is informed about the existence of a functional mechanism,
-                allowing to reach the next or previous element that
-                can receive focus with the keyboard</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.1.1 - 2.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H91 - G21 - F10</p>
-      </article>
-      <ul class="navTheme">
-        <li class="haut"><a href="#toc">Table of contents</a></li>
-      <li class="haut"><a href="#navigation">Go to category: Navigation</a></li>
-      </ul>
-         <article id="consultation" class="thematique">
-        <header>
-        <h2>Consultation</h2>
-          <h3>General guidelines</h3>
-          <p>Check that the user can control the refresh processes,
-            sudden changes in luminosity, openings of new windows and
-            moving or blinking content. Specify when a content opens
-            in a new window and provide information regarding
-            viewing of files to download. Do not make the completion
-            of a task rely upon a time limit except if it is
-            essential and ensure that entered data is retrieved
-            after an authenticated session has expired. Ensure that
-            unusual phrases and jargon are made explicit. Provide
-            accessible versions or make downloadable documents
-            accessible.</p>
-        </header>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-1">Criterion 13.1 [A] For each Web page, can
-          the user control each time limit that modifies content (except in <a title="Particular cases for criterion 13.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-13-1-1"> Test 13.1.1: For each Web page, does
-            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mProcedeRafraichissement">refresh
-              process</a> or <a href="./RGAA3.0_Glossary_English_version_v1.html#mRedirectAuto">automatic
-              redirection</a> (code, script, <code>object</code> tag, <code>applet</code> tag,
-            <code>meta</code> tag) meet one of the following conditions (except in <a title="Particular cases for criterion 13.1"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?
-            <ul>
-              <li> The user can stop or restart the refresh process</li>
-              <li> The user can increase the time limit between two
-                refresh processes by at least a factor of ten</li>
-              <li> The user is warned about the imminence of the
-                refresh, and has at least 20 seconds to increase
-                the time limit before the next refresh</li>
-              <li> The time limit between two refresh processes is at least
-                twenty hours</li>
-            </ul>
-          </li>
-          <li id="test-13-1-2"> Test 13.1.2: For each Web page, is
-            each redirection initiated via the <code>meta</code> tag
-            immediate (except in <a title="Particular cases for criterion 13.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?</li>
-          <li id="test-13-1-3"> Test 13.1.3: For each Web page, does
-            each redirect process initiated via a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            meet one of the following conditions (except in <a title="Particular cases for criterion 13.1"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?
-            <ul>
-              <li> the user can stop or restart the redirect</li>
-              <li> the user can increase the time limit to at least
-                ten times before redirection</li>
-              <li> The user is warned about the imminence of the
-                redirection and has at least twenty seconds to
-                increase the time limit before the next redirection</li>
-              <li> The time limit before the redirection is at least
-                twenty hours</li>
-            </ul>
-          </li>
-          <li id="test-13-1-4">Test 13.1.4: For each Web page, does
-            each server-side redirect process meet one of the
-            following conditions (except in <a title="Particular cases for criterion 13.1"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?
-            <ul>
-              <li> The user can stop or restart the redirection</li>
-              <li> The user can increase the time limit before the
-                redirection to at least ten times</li>
-              <li> The user is warned about the imminence of the
-                redirection and has at least twenty seconds to
-                increase the time limit before the next redirection</li>
-              <li> Time limit before redirection is at least twenty
-                hours</li>
-            </ul>
-          </li>
-          <li id="test-13-1-5">Test 13.1.5: For each Web page, does
-            each process restricting a session time meet one of the
-            following conditions (except in <a title="Particular cases for criterion 13.1"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?
-            <ul>
-              <li>The user can suppress time limit</li>
-              <li>The user can increase time limit</li>
-              <li>Time limit before the session expires is at least
-                twenty hours.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            2.2.1 - 2.2.2 - 2.2.4 - 3.2.5</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): F40 - F41 - F61 - F58 -
-            G76 - G186 - G198 -  H76 - SVR1- SCR1 - SCR36 - G133 -
-            G180 - G75 - G110 - SCR16</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-2">Criterion 13.2 [A] On each Web page, is
-          the user warned each time a new window opens?</h3>
-        <ul>
-          <li id="test-13-2-1"> Test 13.2.1: On each Web page, for
-            each new window opening launched via a link
-            (target="_blank" attribute) or a JavaScript command, is
-            the user warned?</li>
-          <li id="test-13-2-2"> Test 13.2.2: On each Web page, for
-            each window opening launched via an <code>object</code>, <code>applet</code> or
-            <code>embed</code> tag, is the user warned?</li>
-          <li id="test-13-2-3"> Test 13.2.3: On each Web page, for
-            each window opening launched via a form control, is the
-            user warned? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            2.4.4 - 3.2.5</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G201 - H33 - H83 - F22 -
-            SCR24</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-3">Criterion 13.3 [A] On each Web page, the
-          opening of a new window must not happen without user
-          action. Has this rule been followed?</h3>
-        <ul>
-          <li id="test-13-3-1"> Test 13.3.1: On each Web page, the
-            opening of a new window must not be launched without
-            user action. Has this rule been followed? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            3.2.1 - 3.2.5</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G107 - F22 - F52 - F55 -
-            F60</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-4">Criterion 13.4 [AAA] On each Web page, a
-          task must not require a time limit to be completed, except
-          if it occurs in real time or if this time limit is
-          essential. Has this rule been followed?</h3>
-        <ul>
-          <li id="test-13-4-1"> Test 13.4.1: On each Web page, does
-            each task with a time limit meet one of the following
-            conditions?
-            <ul>
-              <li> The task occurs in real time</li>
-              <li> The task requires a time limit that is essential
-                for the task to occur successfully</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.2.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G5</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-5">Criterion 13.5 [AAA] On each Web page,
-          when an authenticated session is interrupted, is the data
-          entered by the user retrieved after re-authenticating?</h3>
-        <ul>
-          <li id="test-13-5-1">Test 13.5.1: On each Web page, when
-            an authenticated session is interrupted, is the data
-            entered by the user retrieved after re-authenticating? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.2.5</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G105 - G181 - F12</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-6">Criterion 13.6 [A] On each Web page, for
-          each file that can be downloaded, is there sufficient
-          information provided  (except in <a title="Particular cases for criterion 13.6"
-
-            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-6">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-13-6-1"> Test 13.6.1: On each Web page, does
-            each file that can be downloaded via a link or a form
-            have information about its format (except in <a title="Particular cases for criterion 13.6"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-6">particular cases</a>)?</li>
-          <li id="test-13-6-2"> Test 13.6.2: On each Web page, does
-            each file that can be downloaded via a link or a form
-            have information about its weight (except in <a title="Particular cases for criterion 13.6"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-6">particular cases</a>)?</li>
-          <li id="test-13-6-3"> Test 13.6.3: On each Web page, does
-            each file that can be downloaded via a link or a form
-            have information about its human language if necessary (except in <a title="Particular cases for criterion 13.6" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-6">particular cases</a>)? </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.4.4</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): H33</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-7">Criterion 13.7 [A] On each Web page, does
-          each electronic <a href="./RGAA3.0_Glossary_English_version_v1.html#mVaccessible">document
-            that can be downloaded</a> have an accessible version if
-          necessary (except in <a title="Particular cases for criterion 13.7" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-7">particular cases</a>)?</h3>
-        <ul>
-          <li id="test-13-7-1"> Test 13.7.1: On each Web page, does
-            each downloading functionality for an electronic
-            document meet one of the following conditions (except in <a title="Particular cases for criterion 13.7"
-
-              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-7">particular cases</a>)?
-            <ul>
-              <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mVaccessible">document
-                  that can be downloaded</a> is
-                accessibility-supported</li>
-              <li> An alternative accessibility-supported version of
-                the <a href="./RGAA3.0_Glossary_English_version_v1.html#mVaccessible">document
-                  that can be downloaded</a> is available</li>
-              <li> An alternative version of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mVaccessible">documentthat
-                  can be downloaded</a> is available in HTML format</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.1.1 - 1.3.2 - 1.3.1 - 2.4.1 - 2.4.3 - 3.1.1 - 4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G10 - G135 - F15</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-8">Criterion 13.8 [A] For each electronic
-          document with an accessible version, does this version
-          provide the same information?</h3>
-        <ul>
-          <li id="test-13-8-1">Test 13.8.1: Does each electronic
-            document with an accessible version meet one of the
-            following conditions?
-            <ul>
-              <li> The accessibility-supported version provides the
-                same information</li>
-              <li> The alternative version in HTML format is
-                relevant and provides the same information</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.1.1 - 1.3.2 - 1.3.1 - 2.4.1 - 2.4.3 - 3.1.1 - 4.1.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G10 - G135 - F15</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-9">Criterion 13.9 [AAA] On each Web page,
-          are unusual phrases, idioms or jargon made explicit?</h3>
-        <ul>
-          <li id="test-13-9-1">Test 13.9.1: On each Web page, does
-            each phrase used in an unusual or restricted way, each
-            idiom or jargon meet one of the following conditions?
-            <ul>
-              <li> A definition is available in the context right
-                next to the phrase and is specified by the <code>dfn</code> tag</li>
-              <li> A definition is available via a definition list</li>
-              <li> A definition is available in the page</li>
-              <li>The phrase is contained in a link giving to
-                access to the definition.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.3</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G55 - G101 - G112 - G160 -
-            G153 - H54</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-10">Criterion 13.10 [AAA] On each Web page,
-          for each phrase used in an unusual or restricted way, each
-          idiom or jargon with a definition, is this definition
-          relevant?</h3>
-        <ul>
-          <li id="test-13-10-1">Test 13.10.1: On each Web page, for
-            each phrase used in an unusual or restricted way, idiom
-            or jargon with a definition, does this definition meet
-            one of the following conditions?
-            <ul>
-              <li> The content of the associated definition is
-                relevant</li>
-              <li> The content of the <code>dd</code> tag of the definition list
-                is relevant</li>
-              <li> The definition provided by the adjacent context
-                is relevant.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            <a href="http://www.w3.org/Translations/WCAG20-fr/#meaning-idioms">3.1.3</a></p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): <a href="http://www.w3.org/TR/WCAG-TECHS/G55.html">G55</a>
-            - <a href="http://www.w3.org/TR/WCAG-TECHS/G101.html">G101</a>
-            - <a href="http://www.w3.org/TR/WCAG-TECHS/G112.html">G112</a>
-            - <a href="http://www.w3.org/TR/WCAG-TECHS/H54.html">H54</a></p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-11">Criterion 13.11 [A] On each Web page,
-          does each cryptical content (ASCII art, emoticon,
-          cryptical syntax) have an alternative?</h3>
-        <ul>
-          <li id="test-13-11-1"> Test 13.11.1: On each Web page,
-            does each cryptical content (ASCII art, emoticon,
-            cryptical syntax) meet one of the following conditions?
-            <ul>
-              <li> A <code>title</code> attribute is available</li>
-              <li> A definition is provided by the adjacent context</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            1.1.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G160 - G153 - H86 - F71 -
-            F72</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-12">Criterion 13.12 [A] On each Web page,
-          for each cryptical content (ASCII art, emoticon, cryptical
-          syntax) with an alternative, is this alternative relevant?</h3>
-        <ul>
-          <li id="test-13-12-1"> Test 13.12.1: On each Web page,
-            does each cryptical content (ASCII art, emoticon,
-            cryptical syntax) meet one of the following conditions?
-            <ul>
-              <li> the content of the <code>title</code> attribute is relevant</li>
-              <li> the definition provided by the adjacent context
-                is relevant</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            <a href="http://www.w3.org/Translations/WCAG20-fr/#text-equiv-all">1.1.1</a></p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): <a href="http://www.w3.org/TR/WCAG-TECHS/H86.html">H86</a>
-            - <a href="http://www.w3.org/TR/WCAG-TECHS/F71.html">F71</a>
-            - <a href="http://www.w3.org/TR/WCAG-TECHS/F72.html">F72</a></p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-13">Criterion 13.13 [AAA] On each Web page,
-          for each word whose meaning cannot be understood without
-          knowing the pronunciation, is this pronunciation
-          specified?</h3>
-        <ul>
-          <li id="test-13-13-1">Test 13.13.1: On each Web page, does
-            each word whose meaning cannot be understood without
-            knowing the pronunciation, meet one of the following
-            conditions?
-            <ul>
-              <li> The phonetic pronunciation is available in the
-                adjacent context</li>
-              <li> The phonetic pronunciation is accessible via a
-                link</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.6</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G62 - G120 - G121 - G160 -
-            G153</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-14">Criterion 13.14 [AAA] On each Web page,
-          does each text that requires a reading ability more
-          advanced than the lower secondary education level have an
-          alternative version?</h3>
-        <ul>
-          <li id="test-13-14-1"> Test 13.14.1: On each Web page,
-            does each text that requires a reading ability more
-            advanced than the lower secondary education level
-            (except for proper names and title) meet one of the
-            following conditions?
-            <ul>
-              <li> An illustration or graphic symbols adapted to the
-                reading level of the lower secondary education level
-                are available</li>
-              <li> A version in sign language (adapted to the human
-                language of the content) is available</li>
-              <li> A spoken version of the text is available</li>
-              <li> A summary adapted to the reading level of the
-                lower secondary education level is available.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            3.1.5</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G79 - G86 - G103 - G160 -
-            G153</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-15">Criterion 13.15 [A] On each Web page,
-          are <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangeLumi">sudden
-            changes in luminosity or flashing effects</a> used
-          accurately?</h3>
-        <ul>
-          <li id="test-13-15-1">Test 13.15.1: On each Web page, does
-            each animated image (<code>img</code> tag, <code>svg</code> tag, or <code>object</code> tag)
-            causing a suddent change in luminosity or a flashing
-            effect meet one of the following conditions?
-            <ul>
-              <li> The effect's frequency is lower than 3 per
-                second</li>
-              <li> The cumulated area of effects is smaller than
-                or equal to 21,824 pixels</li>
-            </ul>
-          </li>
-          <li id="test-13-15-2"> Test 13.15.2: On each Web page,
-            does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            causing a sudden change in luminosity or a flashing
-            effect meet one of the following conditions?
-            <ul>
-              <li> The effect's frequency is lower than 3 per second</li>
-              <li> The cumulated area of the effects is less
-                than or equal to 21,824 pixels</li>
-            </ul>
-          </li>
-          <li id="test-13-15-3"> Test 13.15.3: On each Web page,
-            does each CSS layout causing a sudden change in
-            luminosity or a flashing effect meet one of the following
-            conditions?
-            <ul>
-              <li> The effect's frequency is lower than 3 per second</li>
-              <li>The cumulated area of the effects is less
-                than or equal to 21,824 pixels</li>
-            </ul>
-          </li>
-          <li id="test-13-15-4"> Test 13.15.4: On each Web page,
-            does each Java applet causing a sudden change in
-            luminosity or a flashing effect meet one of the following
-            conditions?
-            <ul>
-              <li> The effect's frequency is lower than 3 per second</li>
-              <li> The cumulated area of the effects is less
-                than or equal to 21,824 pixels</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.3.1</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G15 - G19 - G176</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-16">Criterion 13.16 [AAA] On each Web page,
-          do the <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangeLumi">sudden
-            changes in luminosity or flashing effects</a> have a
-          frequency lower than or equal to 3 per second?</h3>
-        <ul>
-          <li id="test-13-16-1">Test 13.16.1: On each Web page, does
-            each sudden change in luminosity or a flashing effect
-            caused by an animated image (<code>img</code> tag, <code>svg</code>
-              tag, <code>embed</code> tag, <code>canvas</code> tag, or <code>object</code> tag) have
-            a frequency lower than or equal to 3 per second?</li>
-          <li id="test-13-16-2"> Test 13.16.2: On each Web page,
-            does each sudden change in luminosity or a flashing
-            effect caused by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
-            have a frequency lower than or equal to 3 per second?</li>
-          <li id="test-13-16-3"> Test 13.16.3: On each Web page,
-            does each sudden change in luminosity or a flashing
-            effect caused by CSS layout have a frequency lower than
-            or equal to 3 per second?</li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criterion:
-            2.3.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G19</p>
-        </aside>
-       </section>
-        <section>
-        <h3 id="crit-13-17">Criterion 13.17 [A] On each Web page,
-          can each moving or blinking content be <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleMov">controlled
-            by the user</a>?</h3>
-        <ul>
-          <li id="test-13-17-1">Test 13.17.1: On each Web page, does
-            each moving content that starts moving automatically, meet one
-            of the following conditions?
-            <ul>
-              <li> The motion stops within 5 seconds</li>
-              <li> The user can stop and restart the motion</li>
-              <li> The user can display or hide the moving content</li>
-              <li> The user can display the same information without moving content.</li>
-            </ul>
-          </li>
-          <li id="test-13-17-2"> Test 13.17.2: On each Web page,
-            does each blinking content that starts blinking automatically,
-            meet one of the following conditions?
-            <ul>
-              <li> The blinking stops within 5 seconds</li>
-              <li> The user can stop and restart the blinking</li>
-              <li> The user can display and hide the blinking content</li>
-              <li> The user can display the whole information without blinking content.</li>
-            </ul>
-          </li>
-        </ul>
-        <aside>
-        <h4>Mapping with WCAG 2.0  </h4>
-
-          <p>WCAG 2.0 success criteria:
-            1.2.4 - 1.2.9 - 2.2.1 - 2.2.2</p>
-          <p>WCAG 2.0 sufficient technique(s)
-              and/or failure(s): G4 - G11 - G152 - G186 -
-            G187 - G191 - SM11 - SM12 - F47 - F50 - F4 - F7 - F16 -
-            SCR22 - SCR33 - SCR36</p>
-        </aside>
-       </section>
-      </article>
-  </main>
-</body>
+        <main role="main">
+            <h2 id="howto">How to use the RGAA</h2>
+            <p>
+                The RGAA applies to any HTML content (HTML4, XHTML1, HTML5). For some tests, a reference baseline is used. This baseline takes into account a set of assistive technologies, browsers and operating systems, on which the accessibility of JavaScript-based interface components must be tested, among others. A detailed description is provided here: <a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a>.
+            </p>
+            <h3>Important notice regarding HTML content prior to HTML5 specification</h3>
+            <p>When the HTML code of the page is <em>not</em> HTML5, the HTML5 elements (tags and attributes) required by a criterion or test, are not applicable. Every other criteria or tests remain applicable, including those related to ARIA attributes, states or properties. The following criteria and tests are not applicable:
+            </p>
+            <ul>
+                <li>criterion 1.10;</li>
+                <li>criterion 9.2;</li>
+                <li>test 10.13.3;</li>
+                <li>test 11.10.1 (condition 2, relative to the HTML5 attribute <code>required</code>).</li>
+            </ul>
+            <h3>Validation process</h3>
+            <p>
+                For each criterion, compliance is defined as follows:
+            </p>
+            <ul>
+                <li>Compliant (C): all applicable tests are passed</li>
+                <li>Non Compliant (NC): at least one applicable test is failed</li>
+                <li>Not Applicable (NA): there is no content targeted by the criterion.</li>
+            </ul>
+            <p>
+                The RGAA proposes two additional compliance statuses:
+            </p>
+            <ul>
+                <li>Derogated (D): some contents targeted by the criterion will meet compliance by derogation</li>
+                <li>Not tested (NT): the criterion has not been tested.</li>
+            </ul>
+            <p class="navTheme">
+                <a href="#cadres">Go to category: Frames</a>
+            </p>
+            <article id="images">
+                <header>
+                    <h2>Images</h2>
+                    <p>WCAG principle: perceivable.</p>
+                    <h3>General guidelines</h3>
+                    <p>Give each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
+                            conveying information</a> a relevant <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text
+                            alternative</a> and a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed description</a> if necessary. Replace images of text with styled text when possible.
+                    </p>
+                </header>
+                <section>
+                    <h3 id="crit-1-1">
+                        Criterion 1.1 [A] Does each image have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text alternative</a>?
+                    </h3>
+                    <ul>
+                        <li id="test-1-1-1">
+                            Test 1.1.1: Does each image (<code>img</code> tag) have an <code>alt</code> attribute?
+                        </li>
+                        <li id="test-1-1-2">
+                            Test 1.1.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mZone">area</a> (<code>area</code> tag) of an
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgReactive">image map</a> have an <code>alt</code> attribute?
+                        </li>
+                        <li id="test-1-1-3">
+                            Test 1.1.3: Does each form button
+                            (<code>input</code> tag with the <code>type="image"</code> attribute) have an <code>alt</code>
+                            attribute?
+                        </li>
+                        <li id="test-1-1-4">
+                            Test 1.1.4: Does each area (<code>area</code> tag) of a server-side image map have an equivalent link in the page?
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0</h4>
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or failure(s):  H36 - H37 - H53 - H24 - F65</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-2">
+                        Criterion 1.2 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgDeco">decorative
+                            image</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text
+                            alternative</a>, is this alternative empty?
+                    </h3>
+                    <ul>
+                        <li id="test-1-2-1">
+                            Test 1.2.1: Does each decorative image (<code>img</code> tag), without caption and with an
+                            <code>alt</code> attribute, meet the following conditions:
+                            <ul>
+                                <li>The <code>alt</code> attribute has an empty value (<code>alt=""</code>)</li>
+                                <li>The decorative image does not have a <code>title</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-2-2">
+                            Test 1.2.2: Does each non clickable area  (<code>area</code> tag with no
+                            <code>href</code> attribute), not conveying any  information, and with an <code>alt</code> attribute,
+                            meet the following conditions:
+                            <ul>
+                                <li>The <code>alt</code> attribute has an empty value (<code>alt=""</code>)</li>
+                                <li>The non clickable area does not have a <code>title</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-2-3">
+                            Test 1.2.3: For each image object without caption (<code>object</code> tag with the attribute <code>type="image/&hellip;"</code>), not conveying any information, is the text alternative between
+                            <code>&lt;object&gt;</code> and  <code>&lt;/object&gt;</code> empty?
+                        </li>
+                        <li id="test-1-2-4">
+                            Test 1.2.4: Does each decorative vector image (<code>svg</code> tag), not conveying any information, and with an alternative, meet the following conditions:
+                            <ul>
+                                <li>The <code>svg</code> tag has a <code>role="img"</code></li>
+                                <li>The <code>svg</code> tag, or one of its children, has no ARIA role, property or state, that aims at labeling the vector image (<code>aria-label</code>, <code>aria-describedby</code>, or
+                                    <code>aria-labelledby</code>, for example)</li>
+                                <li>The <code>title</code> and <code>desc</code> tags are missing, or empty</li>
+                                <li>The <code>svg</code> tag, or one of its children, has no <code>title</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-2-5">
+                            Test 1.2.5: For each decorative bitmap image (<code>canvas</code> tag), there must be no text content
+                            between <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code>. Has this
+                            rule been followed?
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-2">technical note about the <code>presentation</code> role</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0</h4>
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or failure(s): H67 - G196 - C9 - F39 - F38 - ARIA4 - ARIA10</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-3">
+                        Criterion 1.3 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image conveying information</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text alternative</a>, is this alternative relevant (except in
+                        <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
+                            cases</a>)?
+                    </h3>
+                    <ul>
+                        <li id="test-1-3-1">
+                            Test 1.3.1: Does each image (<code>img</code> tag)
+                            conveying information, with an <code>alt</code> attribute, meet
+                            the following conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
+                                cases</a>):
+                            <ul>
+                                <li>The <code>alt</code> attribute has a relevant value</li>
+                                <li>If present, the value of the <code>title</code> attribute
+                                    matches the value of the <code>alt</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-3-2">
+                            Test 1.3.2: Does each area (<code>area</code> tag),
+                            conveying information, and with an <code>alt</code> attribute,
+                            meet the following conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
+                                cases</a>):
+                            <ul>
+                                <li>The <code>alt</code> attribute has a relevant value</li>
+                                <li>If present, the value of the <code>title</code> attribute
+                                    matches the value of the <code>alt</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-3-3">
+                            Test 1.3.3: For each button associated
+                            with an image (<code>input</code> tag with the attribute
+                            <code>type="image"</code>), and with an <code>alt</code> attribute, is the content
+                            of this attribute relevant (except in <a title="Particular cases for criterion 1.3"  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular cases</a>)?
+                        </li>
+                        <li id="test-1-3-4">
+                            Test 1.3.4: Does each image object
+                            (<code>object</code> tag with the attribute <code>type="image/&hellip;"</code>),
+                            conveying information, meet one of the following
+                            conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
+                                cases</a>)?
+                            <ul>
+                                <li>The image object is immediately followed by an
+                                    adjacent link giving access to a page or a chunk
+                                    of text containing a relevant alternative</li>
+                                <li>The user can replace the image
+                                    object by a relevant text alternative, via a provided mechanism</li>
+                                <li>The user can replace the image
+                                    object by an image with a relevant alternative, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-3-5">
+                            Test 1.3.5: Does each embedded image
+                            (<code>embed</code> tag with the attribute <code>type="image/&hellip;"</code>),
+                            conveying information, meet one of the following
+                            conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
+                                cases</a>)?
+                            <ul>
+                                <li>The embedded image is immediately followed by an
+                                    adjacent link giving access to a page or a chunk
+                                    of text containing a relevant alternative</li>
+                                <li>The user can replace the embedded image
+                                    by a relevant text alternative, via a provided mechanism</li>
+                                <li>The user can replace the embedded image
+                                    by an image with a relevant alternative, via a provided mechanism</li>
+
+                            </ul>
+                        </li>
+                        <li id="test-1-3-6">
+                            Test 1.3.6: Does each vector image (<code>svg</code>
+                            tag), conveying information, and with an alternative, meet
+                            one of the following conditions (except in <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
+                                cases</a>):
+                            <ul>
+                                <li>The <code>svg</code> tag has a <code>role="img"</code> </li>
+                                <li>The <code>svg</code> tag has an <code>aria-label</code> property with a
+                                    relevant value, matching the <code>title</code> attribute of the
+                                    <code>svg</code> tag, if present</li>
+                                <li>The <code>svg</code> tag has a <code>desc</code> tag with a relevant
+                                    content, equal to the <code>title</code> attribute of the <code>svg</code>
+                                    tag, if present</li>
+                                <li>An adjacent link gives access to an alternative
+                                    with relevant content, equal to the <code>title</code> attribute
+                                    of the <code>svg</code> tag, if present</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-3-7">
+                            Test 1.3.7: For each vector image (<code>svg</code> tag), conveying
+                            information, and with an alternative,
+                            is this alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by
+                            assistive technologies?
+                        </li>
+                        <li id="test-1-3-8">
+                            Test 1.3.8: For each bitmap image (<code>canvas</code> tag),
+                            conveying information, and with an alternative
+                            (content between <code>&lt;canvas&gt;</code> and
+                            <code>&lt;/canvas&gt;</code>), is this alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?
+                        </li>
+                        <li id="test-1-3-9">
+                            Test 1.3.9: For each bitmap image (<code>canvas</code> tag),
+                            conveying information, and with an alternative
+                            (content between <code>&lt;canvas&gt;</code> and
+                            <code>&lt;/canvas&gt;</code>), is this alternative relevant?
+                        </li>
+                        <li id="test-1-3-10">
+                            Test 1.3.10: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
+                                conveying information</a> and with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text
+                                alternative</a>, is <a href="./RGAA3.0_Glossary_English_version_v1.html#maltCC">the
+                                text alternative short and concise</a> (except in
+                            <a title="Particular cases for criterion 1.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-3">particular
+                                cases</a>)?
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-3">technical note about the  vector images</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G94 - G95 - F30 - F71 - G196 -
+                            ARIA4</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-4">Criterion 1.4 [A] For each image used as <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
+                        or as <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgTest">test image</a>, with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltTexteImg">text
+                            alternative</a>, does this alternative describe the nature and the purpose of the image?</h3>
+                    <ul>
+                        <li id="test-1-4-1">
+                            Test 1.4.1: Does each image (<code>img</code> tag)
+                            used as a CAPTCHA or test image, with an <code>alt</code>
+                            attribute, meet the following conditions?
+                            <ul>
+                                <li>
+                                    The content of the <code>alt</code> attribute describes the nature and purpose of the image</li>
+                                <li>If present, the value of the <code>title</code> attribute
+                                    matches the value of the <code>alt</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-4-2">
+                            Test 1.4.2: Does each area (<code>area</code> tag) of an image map used as a CAPTCHA or test
+                            image, with an <code>alt</code> attribute, meet the following conditions?
+                            <ul>
+                                <li>The content of the <code>alt</code> attribute describes the nature and purpose of the image </li>
+                                <li>If present, the value of the <code>title</code> attribute
+                                    matches the value of the <code>alt</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-4-3">
+                            Test 1.4.3: For each button associated
+                            with an image (<code>input</code> tag with the attribute
+                            <code>type="image"</code>), used as a CAPTCHA or test image, with an
+                            <code>alt</code> attribute, meet the following conditions?
+                            <ul>
+                                <li>The content of the <code>alt</code> attribute describes the nature and purpose of the image </li>
+                                <li>If present, the value of the <code>title</code> attribute
+                                    matches the value of the <code>alt</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-4-4">
+                            Test 1.4.4: For each image object (<code>object</code>
+                            tag with the attribute <code>type="image/&hellip;"</code>), used
+                            as a CAPTCHA or test image, with a text
+                            alternative, does the text alternative describe the nature and purpose of the image?
+                        </li>
+                        <li id="test-1-4-5">
+                            Test 1.4.5: For each embedded image
+                            (<code>embed</code> tag with the attribute <code>type="image/&hellip;"</code>), used
+                            as a CAPTCHA or test image, with a text
+                            alternative, does the text alternative describe the nature and purpose of the image?
+                        </li>
+                        <li id="test-1-4-6">
+                            Test 1.4.6: Does each vector image (<code>svg</code>
+                            tag), used as a CAPTCHA or test image, with a text alternative provided
+                            via the <code>aria-label</code> property or the <code>desc</code> tag, meet the following conditions?
+                            <ul>
+                                <li>The text alternative provided via the
+                                    <code>aria-label</code> property describes the nature and purpose of the
+                                    image, and matches the value of the <code>title</code>
+                                    attribute of the <code>svg</code> tag, if present
+                                </li>
+                                <li>The text alternative provided via the <code>desc</code>
+                                    tag describes the nature and purpose of the
+                                    image, and matches the value of the <code>title</code>
+                                    attribute of the <code>svg</code> tag, if present
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-1-4-7">
+                            Test 1.4.7: For each vector image (<code>svg</code> tag), used  as a CAPTCHA or test image, with a text
+                            alternative, is this alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?
+                        </li>
+                        <li id="test-1-4-8">
+                            Test 1.4.8: For each bitmap image (<code>canvas</code> tag), used
+                            as a CAPTCHA or test image, with a text
+                            alternative, does this alternative describe the nature and purpose of the image?
+                        </li>
+                        <li id="test-1-4-9">Test 1.4.9: For each bitmap image (<code>canvas</code> tag), used
+                            as a CAPTCHA or test image, with a text
+                            alternative, is this alternative
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or failure(s): G143 - G100</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-5">
+                        Criterion 1.5 [A] For each image used as  <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>,
+                        is a solution for alternative access to the content or to
+                        the purpose of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>  available?
+                    </h3>
+                    <ul>
+                        <li id="test-1-5-1">
+                            Test 1.5.1: Does each image (<code>img</code>,
+                            area, <code>object</code>, <code>embed</code>, <code>svg</code>, <code>canvas</code> tags) used as <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>  meet one of the following conditions?
+                            <ul>
+                                <li>Another non graphic form of <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
+                                    is available, at least</li>
+                                <li>Another solution to access the functionality
+                                    protected by the <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
+                                    is available</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-5-2"> Test 1.5.2: Does each button
+                            associated with an image (<code>input</code> tag with the attribute
+                            <code>type="image"</code>) used as <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
+                            meet one of the following conditions?
+                            <ul>
+                                <li>Another non graphic form of <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
+                                    is available, at least
+                                </li>
+                                <li>Another solution to access the functionality
+                                    protected by the <a href="./RGAA3.0_Glossary_English_version_v1.html#mcaptcha">CAPTCHA</a>
+                                    is available</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G144</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-6">Criterion 1.6 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
+                            conveying information</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                            description</a> if necessary?</h3>
+                    <ul>
+                        <li id="test-1-6-1"> Test 1.6.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
+                                conveying information</a> (<code>img</code> tag) needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed description</a>, meet one of the following conditions?
+                            <ul>
+                                <li> A <code>longdesc</code> attribute providing the <a href="./RGAA3.0_Glossary_English_version_v1.html#mUrl">URL</a>
+                                    of a page that contains the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> is available</li>
+                                <li> An <code>alt</code> attribute that contains the reference to a
+                                    <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> adjacent to the image is available</li>
+                                <li> There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a  href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a></li>
+                            </ul>
+                        </li>
+                        <li id="test-1-6-2"> Test 1.6.2: Does each image object
+                            (<code>object</code> tag with an attribute <code>type="image/&hellip;"</code>)
+                            conveying information needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                description</a>, meet one of the following conditions?
+                            <ul>
+                                <li>There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a></li>
+                                <li>There is a clearly identifiable <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> adjacent to the image object
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-1-6-3"> Test 1.6.3: Does each embedded image
+                            (<code>embed</code> tag with an attribute <code>type="image/&hellip;"</code>) conveying
+                            information needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                description</a>, meet one of the following conditions?
+                            <ul>
+                                <li>There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a
+
+                                        href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a></li>
+                                <li>There is a clearly identifiable <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> adjacent to the embedded image
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-1-6-4">Test 1.6.4:
+                            Does each image button (<code>input</code> tag with the attribute
+                            <code>type="image"</code>), needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                description</a>, meet one of the following conditions?
+                            <ul>
+                                <li>
+                                    An <code>alt</code> attribute containing the reference to a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">
+                                        detailed  description</a> adjacent  to the image is available</li>
+                                <li> There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (<a href="./RGAA3.0_Glossary_English_version_v1.html#mUrl">URL</a>
+                                    or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> </li>
+                            </ul>
+                        </li>
+                        <li id="test-1-6-5">Test 1.6.5: Does each vector image
+                            (<code>svg</code> tag) conveying information needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                description</a>, meet one of the following conditions?
+                            <ul>
+                                <li>There is an <code>aria-label</code> property referencing a
+                                    detailed description adjacent to the vector image</li>
+                                <li>There is a <code>desc</code> tag containing a reference to a
+                                    detailed description adjacent to the vector image</li>
+                                <li>There is a <code>desc</code> tag containing a detailed
+                                    description</li>
+                                <li>There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-1-6-6">Test 1.6.6: For each vector image (<code>svg</code> tag), with a
+                            reference to a detailed description provided via an
+                            <code>aria-label</code> property or a <code>desc</code> tag, is this reference
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?</li>
+                        <li id="test-1-6-7">Test 1.6.7: Does each bitmap image
+                            (<code>canvas</code> tag) conveying information needing a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                description</a>, meet one of the following conditions?
+                            <ul>
+                                <li>There is a chunk of text between <code>&lt;canvas&gt;</code>
+                                    and <code>&lt;/canvas&gt;</code> referencing a detailed
+                                    description adjacent to the bitmap image</li>
+                                <li>There is a text content between <code>&lt;canvas&gt;</code> and
+                                    <code>&lt;/canvas&gt;</code> serving as a detailed description</li>
+                                <li>There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (URL or  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>) giving access to the <a  href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a></li>
+                            </ul>
+                        </li>
+                        <li id="test-1-6-8">Test 1.6.8: For each bitmap image (<code>canvas</code> tag),
+                            with a reference to an adjacent detailed
+                            description, is this reference <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies?
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-6">technical note about vector images and the use of the <code>aria-describedby</code> property</a>.        </p>
+
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G92 - G74 - G73 - H45 - ARIA6</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-7">Criterion 1.7 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
+                            conveying information</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                            description</a>, is this description relevant?</h3>
+                    <ul>
+                        <li id="test-1-7-1">Test 1.7.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgInfo">image
+                                conveying information</a> (<code>img</code> or <code>input</code>  tag with the
+                            attribute  <code>type="image"</code>) with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                description</a> meet one of the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> referenced via the URL in the
+                                    <code>longdesc</code> attribute is relevant</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> available in the page and
+                                    identified in the <code>alt</code> attribute is relevant</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> available via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> is relevant</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-7-2">Test 1.7.2: Does each image object
+                            (<code>object</code> tag with the attribute  <code>type="image/&hellip;"</code>) with a
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                description</a> meet one of the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> adjacent to the object image is
+                                    relevant</li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mDescDetaillee">detailed
+                                        description</a> available via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> is relevant</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-7-3">Test 1.7.3: Does each embedded image
+                            (<code>embed</code> tag with the attribute  <code>type="image/&hellip;"</code>) with a
+                            detailed description meet one of the following
+                            conditions?
+                            <ul>
+                                <li>The detailed description adjacent to the embedded
+                                    image is relevant</li>
+                                <li>The detailed description available via an adjacent
+                                    link is relevant</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-7-4">Test 1.7.4: Does each vector image
+                            (<code>svg</code> tag) with a detailed description meet one of the
+                            following conditions?
+                            <ul>
+                                <li>The detailed description adjacent to the vector
+                                    image is relevant</li>
+                                <li>The detailed description available via an adjacent
+                                    link is relevant</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-7-5">Test 1.7.5: For each vector image (<code>svg</code>
+                            tag) with a detailed description, is this detailed
+                            description <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive
+                            technologies?</li>
+                        <li id="test-1-7-6">Test 1.7.6: Does each bitmap image
+                            (<code>canvas</code> tag) with a detailed description meet one of the
+                            following conditions?    
+                            <ul>
+                                <li>The detailed description adjacent to the bitmap
+                                    image is relevant</li>
+                                <li>The detailed description available between
+                                    <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code> is relevant</li>
+                                <li>The detailed description available via an adjacent
+                                    link is relevant</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-7-7">Test 1.7.7: For each bitmap image
+                            (<code>canvas</code> tag) with a detailed description between
+                            <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code>, is this detailed
+                            description <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive
+                            technologies?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G92- F67</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-8">Criterion 1.8 [AA] When an alternate
+                        mechanism is missing, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgText">image
+                            of text</a> conveying information must be replaced with
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                            text</a>, if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8"
+
+                                                                                         href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-1-8-1"> Test 1.8.1: When an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
+                                mechanism</a> is missing, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgText">image
+                                of text</a> (<code>img</code> tag) conveying information must be
+                            replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a>, if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
+                        <li id="test-1-8-2"> Test 1.8.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgReactive">image
+                                map</a> (<code>img</code> or <code>object</code> tag with the <code>usemap</code> or <code>ismap</code> attribute),
+                            when an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
+                                mechanism</a> is missing, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneTexte">text
+                                area</a> (<code>area</code> tag) conveying information must be
+                            replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
+                        <li id="test-1-8-3"> Test 1.8.3: For each <code>form</code> tag, when
+                            an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
+                                mechanism</a> is missing, each button "image of text"
+                            (<code>input</code> tag with the attribute <code>type="image"</code>) conveying
+                            information must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a>, if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
+                        <li id="test-1-8-4"> Test 1.8.4: When an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
+                                mechanism</a> is missing, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgTextObj">object
+                                image of text</a> (<code>object</code> tag with the attribute
+                            <code>type="image/&hellip;"</code>) conveying information must be replaced
+                            with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
+                        <li id="test-1-8-5"> Test 1.8.5: When an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
+                                mechanism</a> is missing, each embedded image of text
+                            (<code>embed</code> tag with the attribute <code>type="image/&hellip;"</code>)
+                            conveying information must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
+                        <li id="test-1-8-6">Test 1.8.6: When an <a href="./RGAA3.0_Glossary_English_version_v1.html#mMecaRempl">alternate
+                                mechanism</a> is missing, each bitmap image of text
+                            (<code>canvas</code> tag) conveying information must be replaced with
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-8">particular cases</a>)?</li>
+                    </ul>
+                    <aside>
+
+                        <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-8">technical note about   vector images of type text</a>.
+                        </p>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.4.5</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G136 - G140 - C22 - C30</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-9">Criterion 1.9 [AAA] Each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgText">image
+                            of text</a> conveying information must be replaced with
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                            text</a>. Has this rule been followed (except in <a title="Particular cases for criterion 1.9"
+
+                                                                            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-1-9-1"> Test 1.9.1: Each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgText">image
+                                of text</a> (<code>img</code> tag) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
+                        <li id="test-1-9-2"> Test 1.9.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgReactive">image
+                                map</a> (<code>img</code> or <code>object</code> tag with the <code>usemap</code> attribute),
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneTexte">text
+                                area</a> (<code>area</code> tag) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
+                        <li id="test-1-9-3"> Test 1.9.3: For each <code>form</code> tag, each
+                            button "image of text" (<code>input</code> tag with the attribute
+                            <code>type="image"</code>) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
+                        <li id="test-1-9-4"> Test 1.9.4: Each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImgTextObj">text
+                                image object</a> (<code>object</code> tag with the attribute
+                            <code>type="image/&hellip;"</code>) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
+                        <li id="test-1-9-5"> Test 1.9.5: Each embedded image of
+                            text (<code>embed</code> tag with the attribute <code>type="image/&hellip;"</code>)
+                            must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
+                        <li id="test-1-9-6"> Test 1.9.6: Each bitmap image of text
+                            (<code>canvas</code> tag) must be replaced with <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteStyle">styled
+                                text</a> if possible. Has this rule been followed (except in <a title="Particular cases for criterion 1.9" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit1-9">particular cases</a>)?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.4.9</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G140 - C22 - C30</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-1-10">Criterion 1.10
+                        [A] Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mImageCaption">image caption</a> correctly associated with the
+                        corresponding image, if necessary?</h3>
+                    <ul>
+                        <li id="test-1-10-1">Test 1.10.1: Does each image with a
+                            caption (<code>img</code> tag or <code>input</code> tag with the attribute
+                            <code>type="image"</code>, associated with an adjacent caption) meet,
+                            if necessary, the following conditions?
+                            <ul>
+                                <li> The image (<code>img</code> tag) and its caption are contained
+                                    in a <code>figure</code> tag</li>
+                                <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
+                                <li>The content of the <code>alt</code> attribute contains a
+                                    reference to the adjacent caption</li>
+                                <li>The value of the <code>title</code> attribute of the image, if
+                                    present, is strictly equal to the value of the <code>alt</code>
+                                    attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-10-2">Test 1.10.2: Does each image object with a caption (<code>object</code> tag with the attribute <code>type="image/&hellip;"</code>,
+                            associated with an adjacent caption) meet, if necessary,
+                            the following conditions?
+                            <ul>
+                                <li> The image (<code>object</code> tag) and its caption are
+                                    contained in a <code>figure</code> tag</li>
+                                <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
+                            </ul>
+                        </li>
+                        <li id="test-1-10-3">Test 1.10.3: Does each embedded image
+                            with a caption (<code>embed</code> tag with the attribute
+                            <code>type="image/&hellip;"</code>, associated with an adjacent caption)
+                            meet, if necessary, the following conditions?
+                            <ul>
+                                <li> The embedded image (<code>embed</code> tag) and its caption
+                                    are contained in a <code>figure</code> tag</li>
+                                <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
+                                <li>The content of the <code>alt</code> attribute contains a
+                                    reference to the adjacent caption</li>
+                                <li>The value of the <code>title</code> attribute of the image, if
+                                    present, is strictly equal to the value of the <code>alt</code>
+                                    attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-10-4">Test 1.10.4: Does each vector image
+                            with a caption (<code>svg</code> tag associated with an adjacent
+                            caption) meet, if necessary, the following conditions?
+                            <ul>
+                                <li> The vector image (<code>svg</code> tag) and its caption are
+                                    contained in a <code>figure</code> tag</li>
+                                <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
+                                <li>The content of the <code>aria-label</code> property or the <code>desc</code>
+                                    tag of the vector image contains a reference to the
+                                    adjacent caption</li>
+                                <li>The value of the <code>title</code> attribute of the vector
+                                    image (<code>svg</code> tag), if present, is strictly equal to
+                                    the content of the <code>aria-label</code> property or the <code>desc</code>
+                                    tag used as an alternative</li>
+                            </ul>
+                        </li>
+                        <li id="test-1-10-5">Test 1.10.5: Does each bitmap image
+                            with a caption (<code>canvas</code> tag associated with an adjacent
+                            caption) meet, if necessary, the following conditions?
+                            <ul>
+                                <li> The bitmap image (<code>canvas</code> tag) and its caption are
+                                    contained in a <code>figure</code> tag</li>
+                                <li>The <code>figure</code> tag has an attribute <code>role="group"</code></li>
+                                <li>The content between <code>&lt;canvas&gt;</code> and
+                                    <code>&lt;/canvas&gt;</code> contains a reference to the adjacent
+                                    caption</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit1-10">technical note about captioned images</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0 </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.1.1 - 4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or failure(s): G140 - ARIA4- ARIA6</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#images">Go to category: Images</a></li>
+                <li class="bas"><a href="#couleurs">Go to category: Colors</a></li>
+            </ul>
+            <article id="cadres" class="thematique">
+                <header>
+                    <h2>Frames </h2>
+                    <p>WCAG principle: robust.</p>
+                    <h3>General guidelines</h3>
+                    <p>
+                        Provide each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a> with a relevant title.
+                    </p>
+                </header>
+                <section>
+                    <h3 id="crit-2-1">Criterion 2.1 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a>
+                        have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreCadre">frame
+                            title</a>?</h3>
+                    <ul>
+                        <li id="test-2-1-1">Test 2.1.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a>
+                            (<code>iframe</code> tag) have a <code>title</code> attribute?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): H64</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-2-2">Criterion 2.2 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a>
+                        with a frame title, is this <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreCadre">frame
+                            title</a> relevant?</h3>
+                    <ul>
+                        <li id="test-2-2-1"> Test 2.2.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mCadreEnLigne"><code>iframe</code></a>
+                            (<code>iframe</code> tag) with a <code>title</code> attribute, is the content of
+                            this attribute relevant?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): H64</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#cadres">Go to category: Frames</a></li>
+                <li class="bas"><a href="#multimedia">Go to category: Multimedia</a></li>
+            </ul>
+            <article id="couleurs" class="thematique">
+                <header>
+                    <h2>Colors</h2>
+                    <p>WCAG principle: perceivable.</p>
+                    <h3>General guidelines</h3>
+                    <p>Do not provide <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                        through color only, and use sufficient color contrasts.</p>
+                </header>
+
+                <section>
+                    <h3 id="crit-3-1">Criterion 3.1 [A] On each Web page, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> must
+                        not  be conveyed only through color. Has this rule been
+                        followed?</h3>
+                    <ul>
+                        <li id="test-3-1-1"> Test 3.1.1: For each word or for each
+                            group of words where color is used to convey <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>,
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                            must not be conveyed only through color. Has this rule been
+                            followed?</li>
+                        <li id="test-3-1-2"> Test 3.1.2: For each color indication
+                            provided by a text, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                            must not be conveyed only through color. Has this rule been
+                            followed?</li>
+                        <li id="test-3-1-3"> Test 3.1.3: For each image <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoDonneeCouleur">conveying
+                                information</a>, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                            must not be conveyed only through color. Has this rule been
+                            followed?</li>
+                        <li id="test-3-1-4"> Test 3.1.4: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mPropCouleur">CSS
+                                property defining a color</a> and conveying
+                            information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                            must not be conveyed only through color. Has this rule been
+                            followed?</li>
+                        <li id="test-3-1-5"> Test 3.1.5: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> conveying information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                            must not be conveyed only through color. Has this rule been
+                            followed?</li>
+                        <li id="test-3-1-6"> Test 3.1.6: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non-time-based
+                                media</a> conveying
+                            information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                            must not be conveyed only through color. Has this rule been
+                            followed?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria: 1.4.1 -
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G14 - G182 - G111 - G117 - G138 -
+                            G205</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-3-2">Criterion 3.2 [A] On each Web page, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
+                        must not be conveyed only through color. Has this rule been
+                        implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</h3>
+                    <ul>
+                        <li id="test-3-2-1"> Test 3.2.1: For each word or a group
+                            of words, whose color conveys information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                            must not be conveyed only through color. Has this rule been
+                            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
+                        <li id="test-3-2-2"> Test 3.2.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a>
+                            conveyed through color and specified by a word or a group of
+                            words, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
+                            must not be conveyed only through color. Has this rule been
+                            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
+                        <li id="test-3-2-3"> Test 3.2.3: For each image <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoDonneeCouleur">conveying
+                                information</a>, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
+                            must not be conveyed only through color. Has this rule been
+                            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
+                        <li id="test-3-2-4"> Test 3.2.4: For each CSS element
+                            background property conveying
+                            information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
+                            must not be conveyed only through color. Has this rule been
+                            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
+                        <li id="test-3-2-5"> Test 3.2.5: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> conveying
+                            information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
+                            must not be conveyed only through color. Has this rule been
+                            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
+                        <li id="test-3-2-6"> Test 3.2.6: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                                time-based media</a> conveying
+                            information, <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoCouleur">information</a> 
+                            must not be conveyed only through color. Has this rule been
+                            implemented in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mPertinent">relevant</a> way?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.4.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G138 - F13</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-3-3">Criterion 3.3 [AA] On each Web page, is
+                        the <a href="./RGAA3.0_Glossary_English_version_v1.html#mContraste">contrast</a>
+                        between the text and background colors sufficient (except in <a title="Particular cases for criterion 3.3"
+
+                                                                                        href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-3-3-1"> Test 3.3.1: On each Web page, do
+                            non-bold texts and images of non-bold text with font sizes smaller than or equal to <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">150% of
+                                the default font size</a> (or 1.5em)  meet one of the
+                            following conditions (except
+                            in <a title="Particular cases for criterion 3.3"  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
+                            <ul>
+                                <li> The contrast ratio between text and its
+                                    background is at least 4.5:1</li>
+                                <li>The user can display the text with
+                                    a contrast ratio of at least 4.5:1, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                        <li id="test-3-3-2"> Test 3.3.2: On each Web page, do bold
+                            texts and images of bold text with font sizes smaller than or equal to <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">120% of the default font size</a> (or
+                            1.2em) meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 3.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
+                            <ul>
+                                <li> The contrast ratio between text and its
+                                    background is at least 4.5:1</li>
+                                <li>The user can display the text with a
+                                    contrast ratio of at least 4.5:1, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                        <li id="test-3-3-3">Test 3.3.3: On each Web page, do
+                            non-bold texts and images of non-bold text with font sizes larger than <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">150% of the default font size</a> (or 1.5em), meet one of
+                            the following conditions (except in <a title="Particular cases for criterion 3.3"  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
+                            <ul>
+                                <li> The contrast ratio between text and its
+                                    background is at least 3:1</li>
+                                <li>The user can display the text with a
+                                    contrast ratio of at least 3:1, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                        <li id="test-3-3-4"> Test 3.3.4: On each Web page, do bold
+                            texts and images of bold text with font sizes larger than <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">120%
+                                of the default font size</a> (or 1.2em), meet one
+                            of the following conditions (except
+                            in <a title="Particular cases for criterion 3.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
+                            <ul>
+                                <li> The contrast ratio between text and its
+                                    background is at least 3:1</li>
+                                <li>The user can display the text with a
+                                    contrast ratio of at least 3:1, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.4.3</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G18 - G136 - G148 - G174 - G145 -
+                            C29</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-3-4">Criterion 3.4 [AAA] On each Web page, is
+                        the <a href="./RGAA3.0_Glossary_English_version_v1.html#mContraste">contrast</a>
+                        between the text and background colors enhanced (except
+                        in <a title="Particular cases for criterion 3.4"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-3-4-1"> Test 3.4.1: On each Web page, do
+                            non-bold texts and images of non-bold text with font sizes smaller than or equal to <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">150% of
+                                the default font size</a> (or 1.5em) meet one of the
+                            following conditions (except
+                            in <a title="Particular cases for criterion 3.4"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
+                            <ul>
+                                <li> The contrast ratio between text and its
+                                    background is at least 7:1</li>
+                                <li>The user can display the text with
+                                    a contrast ratio of at least 7:1, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                        <li id="test-3-4-2"> Test 3.4.2: On each Web page, do bold
+                            texts and images of bold text with font sizes smaller than or equal to <a
+
+                                href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">120% of the default font size</a> (or
+                            1.2em) meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 3.4"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
+                            <ul>
+                                <li> The contrast ratio between text and its
+                                    background is at least 7:1</li>
+                                <li>The user can display the text with
+                                    a contrast ratio of at least 7:1, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                        <li id="test-3-4-3">Test 3.4.3: On each Web page, do
+                            non-bold texts and images of non-bold text with font sizes larger than <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">150%
+                                of the default font size</a> (or 1.5em), meet one of
+                            the following conditions (except
+                            in <a title="Particular cases for criterion 3.4"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
+                            <ul>
+                                <li> The contrast ratio between text and its
+                                    background is at least 4.5:1</li>
+                                <li>The user can display the text with
+                                    a contrast ratio of at least 4.5:1, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                        <li id="test-3-4-4"> Test 3.4.4: On each Web page, do bold
+                            texts and images of bold text with font sizes larger than <a href="./RGAA3.0_Glossary_English_version_v1.html#mFontSize">120%
+                                of the default font size</a> (or 1.2em), meet one
+                            of the following conditions (except
+                            in <a title="Particular cases for criterion 3.4"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit3-">particular cases</a>)?
+                            <ul>
+                                <li> The contrast ratio between text and its
+                                    background is at least 4.5:1</li>
+                                <li>The user can display the text with
+                                    a contrast ratio of at least 4.5:1, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.4.6</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G148 - G17 - G18 - G174 - F83</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#couleurs">Go to category: Colors</a></li>
+                <li class="bas"><a href="#tableaux">Go to category: Tables</a></li>
+            </ul>
+            <article id="multimedia" class="thematique">
+                <header>
+                    <h2>Multimedia</h2>
+                    <h3>General guidelines</h3>
+                    <p>If necessary, provide each time-based media with
+                        relevant <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                            transcript</a>, <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                            captions</a> and a synchronized audio description.
+                        Provide each non time-based media with a relevant text
+                        alternative. Make possible the <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleConsult">viewing
+                            control</a> of each time-based and non time-based
+                        media with the keyboard and ensure that they are
+                        compatible with assistive technologies.</p>
+                </header>
+                <section>
+                    <h3 id="crit-4-1">Criterion 4.1 [A] Does each prerecorded <a
+
+                            href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                            transcript</a> or an audio description if necessary (except
+                        in <a
+
+                            title="Particular cases for criterion 4.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-1-1"> Test 4.1.1: Does each prerecorded
+                            audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions if
+                            necessary (except
+                            in <a title="Particular cases for criterion 4.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li>There is a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> that is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li>There is an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> that can be clearly identified</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-1-2"> Test 4.1.2: Does each prerecorded
+                            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions if necessary
+                            (except
+                            in <a title="Particular cases for criterion 4.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li> There is an <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioOnly">alternative audio-only version</a> that
+                                    is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li>There is an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> that can be clearly identified</li>
+                                <li> A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> is available</li>
+                                <li> There is an alternative version with a
+                                    synchronized audio description that is accessible
+                                    via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-1-3">Test 4.1.3: Does each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions if necessary
+                            (except
+                            in <a title="Particular cases for criterion 4.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li>There is a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> that is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li>There is an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> that can be clearly identified</li>
+                                <li> A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> is available</li>
+                                <li> There is an alternative version with a
+                                    synchronized audio description that is accessible
+                                    via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria: 1.2.1 -
+                            1.2.3</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G58 - G69 - G78 - G158 - G159 -
+                            G173 - G8 - G166 - SM6 - SM7</p>
+
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-2">Criterion 4.2 [A] For each prerecorded <a
+
+                            href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                            transcript</a> or a synchronized audio description, are
+                        these relevant (except
+                        in <a title="Particular cases for criterion 4.2"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-2-1">Test 4.2.1: For each prerecorded
+                            audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                transcript</a>, is this transcript relevant (except
+                            in <a title="Particular cases for criterion 4.2"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)? </li>
+                        <li id="test-4-2-2">Test 4.2.2: Does each prerecorded
+                            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 4.2"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> is relevant</li>
+                                <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> is relevant</li>
+                                <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> of the alternative version is
+                                    relevant</li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioOnly">alternative audio-only version</a> is relevant </li>
+
+                            </ul>
+                        </li>
+                        <li id="test-4-2-3"> Test 4.2.3: Does each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 4.2"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> is relevant</li>
+                                <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> is relevant</li>
+                                <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> of the alternative version is
+                                    relevant</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+                        <p>WCAG 2.0 success criteria: 1.2.1 - 1.2.3</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or failure(s): F30 - F67 - SM6 - SM7</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-3">
+                        Criterion 4.3 [A] Does each prerecorded
+                        synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> have <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                            captions</a> if necessary
+                        (except
+                        in <a title="Particular cases for criterion 4.3" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                    </h3>
+                    <ul>
+                        <li id="test-4-3-1">Test 4.3.1: Does each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 4.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li>The synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                        media</a> has <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a></li>
+                                <li>there is an alternative version with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> that is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">
+                                        adjacent link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li id="test-4-3-2">Test 4.3.2: For each prerecorded
+                                    synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                        media</a> with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> provided through a <code>track</code> tag, does the
+                                    <code>track</code> tag have an attribute <code>kind="captions"</code>?</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.2</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G58 - G93 - G87 - H95 - SM11 -
+                            SM12 - F74 - F75</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-4">Criterion 4.4 [A] For each prerecorded
+                        synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                            captions</a>, are these captions relevant?</h3>
+                    <ul>
+                        <li id="test-4-4-1"> Test 4.4.1: For each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                captions</a>, are these captions relevant? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.2</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G87 - G93 - F8 - F74 - F75 - SM11
+                            - SM12</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-5">Criterion 4.5 [AA] Does each live <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> have <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                            captions</a> or a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                            transcript</a> if necessary (except
+                        in <a title="Particular cases for criterion 4.5"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-5-1"> Test 4.5.1: Does each live audio-only
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 4.5"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li> <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> are available</li>
+                                <li>a version with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li> a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li>an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> can be clearly identified</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-5-2"> Test 4.5.2: Does each synchronized
+                            live <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 4.5"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li> <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> are available</li>
+                                <li> a version with <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li> a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li>an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> can be clearly identified</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria: 1.2.4 -
+                            1.2.9</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G9 - G150 - G151 - G157 - H95 -
+                            SM11 - SM12</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-6">Criterion 4.6 [AA] Are each <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                            captions</a> or <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                            transcript</a>, provided for live <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a>, relevant?</h3>
+                    <ul>
+                        <li id="test-4-6-1"> Test 4.6.1: Does each audio-only live
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> are relevant</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> of the alternative version are
+                                    relevant</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> is relevant</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-6-2"> Test 4.6.2: Does each synchronized
+                            live <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> are relevant</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mSsTitreSynchro">synchronized
+                                        captions</a> of the alternative version are
+                                    relevant</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> is relevant</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria: 1.2.4 -
+                            1.2.9</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): F8</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-7">Criterion 4.7 [AA] Does each prerecorded <a
+
+                            href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> have a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                            description</a> if necessary (except
+                        in <a title="Particular cases for criterion 4.7"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-7-1"> Test 4.7.1: Does each video-only
+                            prerecorded <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions, if
+                            necessary (except
+                            in <a title="Particular cases for criterion 4.7" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>?
+                            <ul>
+                                <li>A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> is available</li>
+                                <li>an alternative version with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> is available</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-7-2"> Test 4.7.2: Does each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 4.7"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li>A sound track for the synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> is available</li>
+                                <li>An alternative version with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                        description</a> is available</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.5</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G8 - G58 - G78 - G173 - H96 - SM1
+                            - SM2 - SM6 - SM7</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-8">Criterion 4.8 [AA] For each prerecorded <a
+
+                            href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> with a synchronized audio description, is this
+                        audio description relevant?</h3>
+                    <ul>
+                        <li id="test-4-8-1"> Test 4.8.1: For each prerecorded
+                            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                description</a>, is this audio description relevant?</li>
+                        <li id="test-4-8-2"> Test 4.8.2: For each synchronized <a
+
+                                href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDesc">audio
+                                description</a>, is this audio description relevant? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.5</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): SM1 - SM2 - SM6 - SM7</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-9">Criterion 4.9 [AAA] Does each prerecorded
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> have a sign language interpretation (except
+                        in <a title="Particular cases for criterion 4.9"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>) if necessary?</h3>
+                    <ul>
+                        <li id="test-4-9-1"> Test 4.9.1: Does each prerecorded
+                            audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> have a sign language interpretation if
+                            necessary, that is adapted to the media language (except
+                            in <a title="Particular cases for criterion 4.9"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</li>
+                        <li id="test-4-9-2"> Test 4.9.2: Does each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> have a sign language interpretation, if
+                            necessary, that is adapted to the media language (except
+                            in <a title="Particular cases for criterion 4.9"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.6</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G54 - G81 - SM13 - SM14 </p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-10">Criterion 4.10 [AAA] For each prerecorded
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> with a sign language interpretation is this
+                        interpretation relevant?</h3>
+                    <ul>
+                        <li id="test-4-10-1"> Test 4.10.1: For each prerecorded
+                            audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a sign language interpretation, is this
+                            interpretation relevant? </li>
+                        <li id="test-4-10-2"> Test 4.10.2: For each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a sign language interpretation, is this
+                            interpretation relevant?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.6</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G54 - G81 - SM13 - SM14</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-11">Criterion 4.11 [AAA] Does each
+                        prerecorded <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> have a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
+                            audio description</a> if necessary (except
+                        in <a title="Particular cases for criterion 4.11"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-11-1"> Test 4.11.1: Does each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions, if
+                            necessary? (except
+                            in <a title="Particular cases for criterion 4.11"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)
+                            <ul>
+                                <li> A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
+                                        audio description</a> is available</li>
+                                <li> An alternative version with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
+                                        audio description</a> is available</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-11-2"> Test 4.11.2: Does each prerecorded
+                            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions, if
+                            necessary? (except
+                            in <a title="Particular cases for criterion 4.11"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)
+                            <ul>
+                                <li> A synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
+                                        audio description</a> is available</li>
+                                <li> An alternative version with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
+                                        audio description</a> is available</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.7</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G8 - G58 - H96 - SM1 - SM2</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-12">Criterion 4.12 [AAA] For each prerecorded
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> with a synchronized extended audio
+                        description, is this audio description relevant?</h3>
+                    <ul>
+                        <li id="test-4-12-1"> Test 4.12.1: For each prerecorded
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
+                                audio description</a>, is this audio description
+                            relevant?</li>
+                        <li id="test-4-12-2"> Test 4.12.2: For each prerecorded
+                            video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mAudioDescE">extended
+                                audio description</a>, is this audio description
+                            relevant?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.7</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G8 - SM1 - SM2</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-13">Criterion 4.13 [AAA] Does each
+                        synchronized or video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                            transcript</a> (except
+                        in <a title="Particular cases for criterion 4.13"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-13-1"> Test 4.13.1: Does each synchronized
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions, if
+                            necessary (except
+                            in <a title="Particular cases for criterion 4.13" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li>a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a>  is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li>an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> can be clearly identified</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-13-2"> Test 4.13.2: Does each video-only <a
+
+                                href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> meet one of the following conditions, if
+                            necessary (except
+                            in <a title="Particular cases for criterion 4.13" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-">particular cases</a>)?
+                            <ul>
+                                <li>a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> is accessible via an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li>an adjacent <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                        transcript</a> can be clearly identified</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.8</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G58 - G69 - G159</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-14">Criterion 4.14 [AAA] For each
+                        synchronized or video-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                            transcript</a>, is this text transcript relevant?</h3>
+                    <ul>
+                        <li id="test-4-14-1"> Test 4.14.1: For each video-only <a
+
+                                href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                transcript</a>, is this text transcript relevant?</li>
+                        <li id="test-4-14-2"> Test 4.14.2: For each synchronized <a
+
+                                href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTranscriptTextuel">text
+                                transcript</a>, is this text transcript relevant? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.2.8</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): F74</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-15">Criterion 4.15 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> be clearly identified (except
+                        in <a title="Particular cases for criterion 4.15"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-15">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-15-1"> Test
+                            4.15.1: For each audio-only, video-only or
+                            synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> , does the adjacent textual content help
+                            to clearly identify the time-based media (except
+                            in <a title="Particular cases for criterion 4.15"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-15">particular cases</a>)?</li>
+                        <li id="test-4-15-2"> Test
+                            4.15.2: For each live audio-only, live video-only or
+                            live synchronized <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> , does the adjacent textual content help
+                            to clearly identify the time-based media (except
+                            in <a title="Particular cases for criterion 4.15"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-15">particular cases</a>)?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G68 - G100</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-16">Criterion 4.16 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                            time-based media</a> have, if
+                        necessary, an alternative (except
+                        in <a title="Particular cases for criterion 4.16"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-16">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-16-1">Test 4.16.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                                time-based media</a> meet, if
+                            necessary, one of the following conditions (except
+                            in <a
+
+                                title="Particular cases for criterion 4.16" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-16">particular cases</a>)?
+                            <ul>
+                                <li>An <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a>, clearly identifiable, links to a URL
+                                    containing an alternative</li>
+                                <li> An <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a>, clearly identifiable, gives access to an
+                                    alternative in the page</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-16-2">Test 4.16.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                                time-based media</a> associated with an alternative
+                            meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 4.16"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-16">particular cases</a>)?
+                            <ul>
+                                <li> The page to which the <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> refers is accessible</li>
+                                <li> The alternative in the page to which the <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienAdj">adjacent
+                                        link</a> refers is accessible.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): H35 - H46</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-17">Criterion 4.17 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                            time-based media</a> with an alternative, is this
+                        alternative relevant?</h3>
+                    <ul>
+                        <li id="test-4-17-1"> Test
+                            4.17.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                                time-based media</a> with an alternative, does this
+                            alternative provide access to the same content, and to
+                            similar functionalities?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): H46 - F30</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-18">Criterion 4.18 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mControlSound">autoplaying sound  be controlled by the user</a>?</h3>
+                    <ul>
+                        <li id="test-4-18-1"> Test 4.18.1: Does each audio
+                            sequence played automatically via an <code>object</code>, <code>video</code>,
+                            <code>audio</code>, <code>embed</code> tag, a JavaScript code or <code>bgsound</code>
+                            property meet one of the following conditions?
+                            <ul>
+                                <li> The audio sequence lasts  3
+                                    seconds or less</li>
+                                <li> The audio sequence can be stopped by an action
+                                    initiated by the user</li>
+                                <li> The volume of the audio sequence can be
+                                    controlled by the user independently from the system
+                                    volume control.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.4.2</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G60 - G170 - G171 - F23 - F93</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-19">Criterion 4.19 [AAA] For each prerecorded
+                        audio-only <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a>, are the dialogues audible enough (except
+                        in <a title="Particular cases for criterion 4.19"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-19">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-19-1"> Test 4.19.1: Does each prerecorded
+                            audio <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a>, played via an <code>object</code>, <code>video</code>,
+                            <code>audio</code>, <code>embed</code> tag, or provided for download,
+                            meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 4.19"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-19">particular cases</a>)?
+                            <ul>
+                                <li> The background sounds can be turned off</li>
+                                <li> The volume of the dialogue track(s) is 20
+                                    decibels higher than the volume of the background
+                                    sounds.</li>
+                                <li>An alternative version, for which the background
+                                    sounds can be turned off, is available</li>
+                                <li>An alternative version in which the volume of the
+                                    dialogue track(s) is 20 decibels higher than the
+                                    volume of the background sounds, is available.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion: 1.4.7</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G56</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-20">Criterion 4.20 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> be, if necessary,
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleClavSour">controlled
+                            by keyboard and mouse</a>?</h3>
+                    <ul>
+                        <li id="test-4-20-1"> Test 4.20.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> have the <a href="./RGAA3.0_Glossary_English_version_v1.html#mFonctionControle">control
+                                features</a> to be played,
+                            if necessary?</li>
+                        <li id="test-4-20-2"> Test
+                            4.20.2: For each time-based media, does each control
+                            feature meet one of the following conditions:
+                            <ul>
+                                <li>    The control feature can be
+                                    reached by the keyboard and by the mouse?</li>
+                                <li>    A keyboard and mouse
+                                    accessible control feature,
+                                    performing the same action, is available in the
+                                    same page
+                                </li>
+                            </ul>
+                        </li>
+
+                        <li id="test-4-20-3"> Test
+                            4.20.3: For each time-based media, does each control
+                            feature meet one of the following conditions:
+                            <ul>
+                                <li>    The control feature
+                                    can be activated by the keyboard and by the mouse?</li>
+                                <li>    A control feature,
+                                    performing the same action, and that can be
+                                    activated by the keyboard and by the mouse, is
+                                    available in the same page
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+                        <p>WCAG 2.0 success criteria: 2.1.1 -
+                            2.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G90 - G4 - G202</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-21">Criterion 4.21 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                            time-based media</a> be controlled by the keyboard and
+                        by the mouse?</h3>
+                    <ul>
+                        <li id="test-4-21-1"> Test
+                            4.21.1: For each non time-based media, does each
+                            control feature meet one of the following conditions:
+                            <ul>
+                                <li>    The control feature can be
+                                    reached by the keyboard and by the mouse?</li>
+                                <li>    A keyboard and mouse
+                                    accessible control feature,
+                                    performing the same action, is available in the
+                                    same page
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-4-21-2"> Test
+                            4.21.2: For each non time-based media, does each
+                            control feature meet one of the following conditions:
+                            <ul>
+                                <li>    The control feature
+                                    can be activated by the keyboard and by the mouse?</li>
+                                <li>    A control feature,
+                                    performing the same action, and that can be
+                                    activated by the keyboard and by the mouse, is
+                                    available in the same page
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria: 2.1.1 -
+                            2.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s) and/or
+                            failure(s): G90 - G4</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-4-22">Criterion 4.22 [A] Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                            media</a> and each non time-based media compatible with
+                        assistive technologies (except
+                        in <a title="Particular cases for criterion 4.22"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-22">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-4-22-1"> Test
+                            4.22.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> and each non time-based media, inserted
+                            via an <code>object</code> or <code>embed</code> tag, meet one of the following
+                            conditions (except
+                            in <a title="Particular cases for criterion 4.22"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit4-22">particular cases</a>)?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mNameRole">name, role, value,
+                                        settings and states changes</a> of the interface components
+                                    are accessible to assistive technologies via an
+                                    accessibility API </li>
+                                <li> An alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCompAccess">compatible with an accessibility API</a> provides the
+                                    same functionalities</li>
+                            </ul>
+                        </li>
+                        <li id="test-4-22-2">Test
+                            4.22.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a> and each non time-based media, inserted
+                            via an <code>object</code> or <code>embed</code> tag, with an alternative <a href="./RGAA3.0_Glossary_English_version_v1.html#mCompAccess">compatible with an accessibility API</a>, meet one of the
+                            following conditions?
+                            <ul>
+
+                                <li>The alternative is
+                                    adjacent to the time-based media, or the non
+                                    time-based media</li>
+                                <li>The alternative can be
+                                    reached via an adjacent link (a URL or an  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a>)</li>
+                                <li>A functionality is
+                                    available to replace the time-based or non
+                                    time-based media by its alternative</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            4.1.2 - 2.1.1 - 2.1.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G10 - G135 - F15 - F54</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#multimedia">Go to category: Multimedia</a></li>
+                <li class="bas"><a href="#liens">Go to category: Links</a></li>
+            </ul>
+            <article id="tableaux" class="thematique">
+                <header>
+                    <h2>Tables</h2>
+                    <p>WCAG principle: perceivable.</p>
+                    <h3>General guidelines</h3>
+                    <p>Provide each  <a
+
+                            href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
+                            table</a>, with a relevant <a href="./RGAA3.0_Glossary_English_version_v1.html#mResumeTab">summary</a>
+                        and a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreTab">title</a>,
+                        clearly identify header cells, use a relevant mechanism
+                        to associate data cells with header cells. Ensure that
+                        each layout table is correctly linearized.</p>
+                </header>
+                <section>
+                    <h3 id="crit-5-1">Criterion 5.1 [A] Does each
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
+                            table</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mResumeTab">summary</a>?
+                    </h3>
+                    <ul>
+                        <li id="test-5-1-1">Test 5.1.1:
+                            Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
+                                table</a> (<code>table</code> tag) have a summary, provided
+                            through the <code>caption</code> tag?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H73</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-5-2">Criterion 5.2 [A] For each
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
+                            table</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mResumeTab">summary</a>,
+                        is this summary relevant?</h3>
+                    <ul>
+                        <li id="test-5-2-1"> Test 5.2.1:
+                            For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonneeComplexe">complex data
+                                table</a> (<code>table</code> tag) with a summary, is this
+                            summary relevant?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H73</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-5-3">Criterion 5.3 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
+                            table</a>, is the linearized content still
+                        understandable?</h3>
+                    <ul>
+                        <li id="test-5-3-1"> Test
+                            5.3.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
+                                table</a> meet the following conditions?
+                            <ul>
+                                <li>the
+                                    linearized content is still understandable</li>
+                                <li>the <code>table</code>
+                                    tag has an attribute <code>role="presentation"</code></li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.2 - 4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): F49 - ARIA4</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-5-4">Criterion 5.4 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
+                            table</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreTab">title</a>?</h3>
+                    <ul>
+                        <li id="test-5-4-1"> Test 5.4.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
+                                table</a> (<code>table</code> tag) have a <code>caption</code> tag?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H39</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-5-5">Criterion 5.5 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
+                            table</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreTab">title</a>,
+                        is this title relevant?</h3>
+                    <ul>
+                        <li id="test-5-5-1"> Test 5.5.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
+                                table</a> (<code>table</code> tag) with a <code>caption</code> tag, does the
+                            content of this tag provide the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreTab">title</a>
+                            of the table? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H39</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-5-6">Criterion 5.6 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
+                            table</a>, are each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnteteTab">column
+                            header</a> and each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnteteTab">row
+                            header</a> correctly identified?</h3>
+                    <ul>
+                        <li id="test-5-6-1"> Test 5.6.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
+                                table</a> (<code>table</code> tag), does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnteteTab">column
+                                header</a> have a <code>th</code> tag?</li>
+                        <li id="test-5-6-2"> Test 5.6.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
+                                table</a> (<code>table</code> tag), does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnteteTab">row
+                                header</a> have a <code>th</code> tag?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H51 - F91</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-5-7">Criterion 5.7 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabDonnee">data
+                            table</a>, is each cell associated with its header using
+                        the appropriate technique?</h3>
+                    <ul>
+                        <li id="test-5-7-1"> Test 5.7.1: Does each header cell (<code>th</code>
+                            tag) applied to the whole row or to the whole column
+                            have a unique <code>id</code> attribute or a <code>scope</code> attribute?</li>
+                        <li id="test-5-7-2"> Test 5.7.2: Does each header cell (<code>th</code>
+                            tag) applied to the whole row or the whole column and
+                            having a <code>scope</code> attribute meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The header has a <code>scope</code> attribute with the value
+                                    "<code>row</code>" for row headers</li>
+                                <li> The header has a <code>scope</code> attribute with the value
+                                    "<code>col</code>" for column headers</li>
+                            </ul>
+                        </li>
+                        <li id="test-5-7-3"> Test 5.7.3: Does each header cell (<code>th</code>
+                            tag) that is not applied to the whole column meet the
+                            following conditions?
+                            <ul>
+                                <li> The header does not have a <code>scope</code> attribute</li>
+                                <li> The header has a unique <code>id</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-5-7-4"> Test 5.7.4: Does each cell (<code>td</code> or <code>th</code>
+                            tag) associated with one or several headers with an <code>id</code> attribute meet the following conditions?
+                            <ul>
+                                <li> The cell has a <code>headers</code> attribute</li>
+                                <li> The <code>headers</code> attribute contains a list of values
+                                    matching the <code>id</code> attributes of the headers associated
+                                    with the cell.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H63 - H43</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-5-8">Criterion 5.8 [A] Each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
+                            table</a> must not use elements intended for data
+                        tables. Has this rule been followed?</h3>
+                    <ul>
+                        <li id="test-5-8-1">Test 5.8.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
+                                table</a> (<code>table</code> tag) meet the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
+                                        table</a> (<code>table</code> tag) does not have any <code>caption</code>,
+                                    <code>th</code>, <code>thead</code>, <code>tfoot</code> tags</li>
+                                <li> The cells of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTabMiseForme">layout
+                                        table</a> (<code>td</code> tag) have no <code>scope</code>, <code>headers</code>,
+                                    <code>colgroup</code>, <code>axis</code> attributes.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): F46</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#tableaux">Go to category: Tables</a></li>
+                <li class="bas"><a href="#script">Go to category: Scripts</a></li>
+            </ul>
+            <article id="liens" class="thematique">
+                <header>
+                    <h2>Links</h2>
+                    <p>WCAG principle: perceivable, operable,
+                        understandable.</p>
+                    <h3>General guidelines</h3>
+                    <p>Provide explicit link text, in particular, with context
+                        information, and use the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
+                            title</a> as sparsely as possible. Add links or a
+                        navigation form to the areas of a server-side image map.</p>
+                </header>
+
+                <section>
+                    <h3 id="crit-6-1">Criterion 6.1 [A] Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLien">link</a>
+                        explicit (except in <a title="Particular cases for criterion 6.1"
+
+                                               href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
+                            cases</a>)?</h3>
+                    <ul>
+                        <li id="test-6-1-1"> Test 6.1.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
+                                context</a> meet one of the following conditions
+                            (except in <a title="Particular cases for criterion 6.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
+                                cases</a>)?
+                            <ul>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
+                                        text</a> alone is sufficient to understand the link
+                                    purpose and target</li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
+                                        context</a> is sufficient to understand the link purpose
+                                    and target</li>
+                            </ul>
+                        </li>
+                        <li id="test-6-1-2"> Test 6.1.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienImage">image
+                                link</a> (content of the <code>alt</code> attribute, text between
+                            <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code>, or text between
+                            <code>&lt;object&gt;</code> and <code>&lt;/object&gt;</code>) meet one of the
+                            following conditions (except in <a title="Particular cases for criterion 6.1"
+
+                                                               href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
+                                cases</a>)?
+                            <ul>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
+                                        text</a> alone is sufficient to understand the link
+                                    purpose and target</li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
+                                        context</a> is sufficient to understand the link purpose
+                                    and target</li>
+                            </ul>
+                        </li>
+                        <li id="test-6-1-3"> Test 6.1.3: Does each
+                            link that doubles a <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneCliquable">clickable
+                                area</a> of a server-side image map meet one
+                            of the following conditions (except in <a title="Particular cases for criterion 6.1"
+
+                                                                      href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
+                                cases</a>)?
+                            <ul>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
+                                        text</a> alone is sufficient to understand the link
+                                    purpose and target</li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
+                                        context</a> is sufficient to understand the link purpose
+                                    and target</li>
+                            </ul>
+                        </li>
+                        <li id="test-6-1-4"> Test 6.1.4: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienComposite">combined
+                                link</a> meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 6.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
+                                cases</a>)?
+                            <ul>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
+                                        text</a> alone is sufficient to understand the link
+                                    purpose and target</li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
+                                        context</a> is sufficient to understand the link purpose
+                                    and target</li>
+                            </ul>
+                        </li>
+                        <li id="test-6-1-5"> Test 6.1.5: Does each  <a href="./RGAA3.0_Glossary_English_version_v1.html#mVectorLink">vector
+                                link</a> meet one of the following conditions (except in <a  title="Particular cases for criterion 6.1"
+                                                                                         href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular
+                                cases</a>)?
+                            <ul>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
+                                        text</a> alone is sufficient to understand the link
+                                    purpose and target</li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mContexteLien">link
+                                        context</a> is sufficient to understand the link purpose
+                                    and target</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.1.1 - 2.4.4 - 2.4.9</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H78 - H79 - H80 - H81 -
+                            H30 - F89 - G91 - G53 - ARIA7 - ARIA8 - F63</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-6-2">Criterion 6.2 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLien">link</a>
+                        with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
+                            title</a>, is this title relevant?</h3>
+                    <ul>
+                        <li id="test-6-2-1"> Test 6.2.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienTexte">text
+                                link</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
+                                title</a> (<code>title</code> attribute), is the content of this
+                            attribute relevant? </li>
+                        <li id="test-6-2-2"> Test 6.2.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienImage">image
+                                link</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
+                                title</a> (<code>title</code> attribute), is the content of this
+                            attribute relevant? </li>
+                        <li id="test-6-2-3"> Test 6.2.3: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneCliquable">clickable
+                                area</a> (<code>area</code> tag) with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
+                                title</a> (<code>title</code> attribute), is the content of this
+                            attribute relevant? </li>
+                        <li id="test-6-2-4"> Test 6.2.4: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienComposite">combined
+                                link</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
+                                title</a> (<code>title</code> attribute), is the content of this
+                            attribute relevant? </li>
+                        <li id="test-6-2-5">Test 6.2.5:
+                            For each  <a href="./RGAA3.0_Glossary_English_version_v1.html#mVectorLink">vector
+                                link</a> with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitreLien">link
+                                title</a> (<code>title</code> attribute), is the content of this
+                            attribute relevant? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H33</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-6-3">Criterion 6.3 [AAA] Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
+                            text</a> alone <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
+                            out of context</a> (except
+                        in <a title="Particular cases for criterion 6.3"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-6-3-1"> Test 6.3.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienTexte">text
+                                link</a> meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 6.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)?
+                            <ul>
+                                <li>The link text is explicit out of its context</li>
+                                <li>The user can get an explicit
+                                    link text out of its context, via a provided mechanism</li>
+                                <li>The content of the link title (<code>title</code> attribute) is
+                                    explicit out of its context</li>
+                            </ul>
+                        </li>
+                        <li id="test-6-3-2"> Test 6.3.2: Is each text for an <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienImage">image
+                                link</a> (content of the <code>alt</code> attribute, text
+                            between <code>&lt;canvas&gt;</code> and <code>&lt;/canvas&gt;</code> or text
+                            between <code>&lt;object&gt;</code> and <code>&lt;/object&gt;</code>) <a
+
+                                href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
+                                out of context</a> (except
+                            in <a title="Particular cases for criterion 6.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)? </li>
+                        <li id="test-6-3-3"> Test 6.3.3: Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">link
+                                text</a> such as a <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneCliquable">clickable
+                                area</a> (content of the <code>alt</code> attribute of an <code>area</code> tag)
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
+                                out of context</a> (except
+                            in <a title="Particular cases for criterion 6.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)? </li>
+                        <li id="test-6-3-4"> Test 6.3.4: Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienComposite">combined
+                                link</a> (content of the text and of the <code>alt</code>
+                            attribute) <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
+                                out of context</a> (except
+                            in <a title="Particular cases for criterion 6.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)? </li>
+                        <li id="test-6-3-5">Test 6.3.5: Is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mVectorLink">vector
+                                link</a>
+                            (content of the alternative of the vector image, <code>svg</code>
+                            tag) <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienHorsContexte">explicit
+                                out of context</a> (except
+                            in <a title="Particular cases for criterion 6.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit6-">particular cases</a>)? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.9</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G91 - G189 - H33 - SCR30</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-6-4">Criterion 6.4 [A] For
+                        each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
+                            link</a> have the same purpose and target?</h3>
+                    <ul>
+                        <li id="test-6-4-1"> Test 6.4.1: For
+                            each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
+                                link</a> of type text have the same purpose and
+                            target?</li>
+                        <li id="test-6-4-2"> Test 6.4.2: For
+                            each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
+                                link</a> of type image have the same purpose and
+                            target?</li>
+                        <li id="test-6-4-3"> Test 6.4.3: For
+                            each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
+                                link</a> of type <a href="./RGAA3.0_Glossary_English_version_v1.html#mZoneCliquable">clickable
+                                area</a> have the same purpose and target?</li>
+                        <li id="test-6-4-4"> Test 6.4.4: For
+                            each web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
+                                link</a> of type combined link have the same purpose
+                            and target?</li>
+                        <li id="test-6-4-5">Test 6.4.5:For each web page, does
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienIdentique">identical
+                                link</a> that are <a href="./RGAA3.0_Glossary_English_version_v1.html#mVectorLink">vector
+                                links</a> have the same purpose and
+                            target?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteri:
+                            2.4.4 - 3.2.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H78 - H79 - H80 - G91 -
+                            G197 - H30 - H33 - ARIA7 - ARIA8</p>
+
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-6-5">Criterion 6.5 [A] On each Web page, does
+                        each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLien">link</a>,
+                        except in <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchors</a>,
+                        have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mIntituleLien">text</a>?</h3>
+                    <ul>
+                        <li id="test-6-5-1"> Test 6.5.1 On each Web page, does
+                            each link (<code>a</code> tag with an <code>href</code>
+                            attribute), except in <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchors</a>,
+                            have a text between <code>&lt;a&gt;</code> and <code>&lt;/a&gt;</code>? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.1.1 - 2.4.4 - 2.4.9</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G91 - H30 - F89</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#liens">Go to category: Links</a></li>
+                <li class="bas"><a href="#elements">Go to category: Mandatory
+                        elements</a></li>
+            </ul>
+            <article id="script" class="thematique">
+                <header>
+                    <h2>Scripts</h2>
+                    <h3>General guidelines</h3>
+                    <p>Provide, if necessary, each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                        with a relevant <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>.
+                        Make each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                        controllable at least by keyboard and mouse, and ensure
+                        that it is compatible with assistive technologies.</p>
+                </header>
+
+                <section>
+                    <h3 id="crit-7-1">Criterion 7.1 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                        support assistive technologies, if necessary?</h3>
+                    <ul>
+                        <li id="test-7-1-1">Test 7.1.1:
+                            Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            generating or controlling an interface component meet
+                            one of the following conditions, if necessary?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mNameRole">name, role, value,
+                                        settings and states changes</a> are accessible to
+                                    assistive technologies via an accessibility API </li>
+                                <li> An accessible interface
+                                    component, allowing access to the same
+                                    functionalities, is available in the page</li>
+                                <li> An accessible <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
+                                    provides the same functionalities.</li>
+                            </ul>
+                        </li>
+                        <li id="test-7-1-2"> Test 7.1.2:
+                            Does each functionality for content insertion
+                            controlled by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>,
+                            use <a href="./RGAA3.0_Glossary_English_version_v1.html#mDOM">properties and methods compliant with the DOM
+                                (Document Object Model) specification</a>? </li>
+                        <li id="test-7-1-3">Test 7.1.3:
+                            Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            generating or controlling an interface component,
+                            having roles, states or properties matching with an
+                            ARIA API Design Pattern, meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The interface component
+                                    complies with the Design Pattern defined by the
+                                    ARIA API</li>
+                                <li>An interface component,
+                                    available in the page, providing access to the same
+                                    functionalities, complies
+                                    with the Design Pattern defined by the ARIA API</li>
+                                <li>The interface component <a href="./RGAA3.0_Glossary_English_version_v1.html#mAdaptsARIADP">adapts a Design Pattern defined by the ARIA API</a></li>
+                                <li>An accessible interface
+                                    component providing access to the same
+                                    functionalities is available in the page</li>
+                            </ul>
+                        </li>
+                        <li id="test-7-1-4"> Test 7.1.4:
+                            Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangeNativeRole">change of native role of an HTML element</a>
+                            respect the rules and recommendations of the HTML5
+                            specifications, and the associated technical notes?</li>
+                        <li id="test-7-1-5">Test 7.1.5:
+                            Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            generating or controlling an interface component, via
+                            roles, states or properties defined by the ARIA API,
+                            meet one of the following conditions?
+                            <ul>
+                                <li> The interface component
+                                    is <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies</li>
+                                <li>An accessible
+                                    alternative provides access to the same
+                                    functionalities
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-7-1-6">Test 7.1.6:
+                            Does each interface component with an ARIA role
+                            <code>application</code> meet one of the following conditions?
+                            <ul>
+                                <li> The interface component
+                                    is <a href="./RGAA3.0_Glossary_English_version_v1.html#mCorrectlyRendered">correctly rendered</a> by assistive technologies</li>
+                                <li>An accessible
+                                    alternative provides access to the same
+                                    functionalities
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit7-1">technical note about the alternatives to scripts</a>.
+                    </p><aside>
+
+
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G10 - G135 - G136 - ARIA4
+                            - ARIA5 - ARIA18 - ARIA19 - SCR21 - F15 - F19 - F42 -
+                            F59 - F79 - F20</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-7-2">Criterion 7.2 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                        with an <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>,
+                        is this <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
+                        relevant?</h3>
+                    <ul>
+                        <li id="test-7-2-1"> Test 7.2.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            beginning with the <code>script</code> tag, and having an <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>,
+                            meet one of the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
+                                    between <code>&lt;noscript&gt;</code> and <code>&lt;/noscript&gt;</code>
+                                    provides access to similar content and functionalities</li>
+                                <li> When JavaScript is disabled, the displayed page
+                                    provides access to  similar content and functionalities</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
+                                    page provides access to similar content and
+                                    functionalities</li>
+                                <li> The server-side script language provides access to
+                                    similar content and functionalities</li>
+                                <li>The alternative
+                                    available in the same page provides access to 
+                                    similar content and functionalities </li>
+                            </ul>
+                        </li>
+                        <li id="test-7-2-2"> Test 7.2.2: Does each non text
+                            element that is updated by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            (in the page or an <code>iframe</code>) and that has an <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
+                            meet the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
+                                    of the non text element is updated</li>
+                                <li> The updated <a href="./RGAA3.0_Glossary_English_version_v1.html#mAltScript">alternative</a>
+                                    is relevant</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            4.1.2 - 1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G136 - F19 - F20</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-7-3">Criterion 7.3 [A] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                        be <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleClavSour">controlled
+                            by keyboard and mouse</a> (except
+                        in <a title="Particular cases for criterion 7.3"
+
+                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-3">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-7-3-1"> Test 7.3.1: Does each element with an
+                            event handler controlled by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 7.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-3">particular cases</a>)?
+                            <ul>
+                                <li> The element is <a href="./RGAA3.0_Glossary_English_version_v1.html#mAAClavierSouris">accessible
+                                        with keyboard and mouse</a></li>
+                                <li> An element that is <a href="./RGAA3.0_Glossary_English_version_v1.html#mAAClavierSouris">accessible
+                                        with keyboard and mouse</a>, performing
+                                    the same action, is available in the page</li>
+                            </ul>
+                        </li>
+                        <li id="test-7-3-2"> Test 7.3.2: Does each element with an
+                            event handler controlled by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            meet one of the following conditions (except
+                            in <a title="Particular cases for criterion 7.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-3">particular cases</a>)?
+                            <ul>
+                                <li> The element can be <a href="./RGAA3.0_Glossary_English_version_v1.html#mAAClavierSouris">activated
+                                        by keyboard and mouse</a></li>
+                                <li> An element that can be <a href="./RGAA3.0_Glossary_English_version_v1.html#mAAClavierSouris">activated
+                                        by keyboard and mouse</a>, performing the
+                                    same action, is available in the page</li>
+                            </ul>
+                        </li>
+                        <li id="test-7-3-3"> Test 7.3.3: A <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            must not remove focus from an element that receives it.
+                            Has this rule been followed (except
+                            in <a title="Particular cases for criterion 7.3"
+
+                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-3">particular cases</a>)?</li>
+                        <li id="test-7-3-4"> Test 7.3.4: Does each interface
+                            component implemented via a role defined by the ARIA
+                            API, and matching a Design Pattern, meet one of the
+                            following conditions?
+                            <ul>
+                                <li> The keyboard interactions comply with the Design
+                                    Pattern for the Esc, Space bar, Tab, and arrow keys,
+                                    at least</li>
+                                <li> An interface component available in the page,
+                                    performing the same action, has keyboard
+                                    interactions complying with the Design Pattern for
+                                    the Esc, Space bar, Tab, and arrow keys, at least</li>
+                                <li>An alternative providing access to the same
+                                    functionalities can be controlled by the keyboard
+                                    and the mouse.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit7-3">technical note about keyboard interactions in the ARIA API</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.3.1 - 2.1.1 - 2.1.3 - 2.4.7</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G202 - SCR2 - SCR20 -
+                            SCR29 - SCR35 - G90 - F42 - F54 - F55</p>
+
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-7-4">Criterion 7.4 [A] For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                        that initiates a <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangContexte">change
+                            of context</a>, is the user warned or can he control it?</h3>
+                    <ul>
+                        <li id="test-7-4-1"> Test 7.4.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            initiating a <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangContexte">change
+                                of context</a> meet one of the following conditions?
+                            <ul>
+                                <li> The user is warned by a text about the <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                                    action and the kind of change before it is activated</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangContexte">change
+                                        of context</a> is initiated by an explicit button
+                                    (<code>input</code> tag of type submit,
+                                    button or image, or <code>button</code> tag) </li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangContexte">change
+                                        of context</a> is initiated by an explicit link</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            3.2.1 - 3.2.2 - 3.2.5</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): F9 - F22 - F36 - F37 - F41
+                            - F76 - G13 - G76 - G80 - G107 - H32 - H84 - SCR19</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-7-5">Criterion 7.5 [AAA] Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                        causing an unrequested <a href="./RGAA3.0_Glossary_English_version_v1.html#mAlerte">alert</a>
+                        be controlled by the user (except in <a title="Particular cases for criterion 7.5"
+
+                                                                href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-5">particular
+                            cases</a>)?</h3>
+                    <ul>
+                        <li id="test-7-5-1">Test 7.5.1: Can each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            causing an unrequested <a href="./RGAA3.0_Glossary_English_version_v1.html#mAlerte">alert</a>
+                            be controlled by the user (except in <a title="Particular cases for criterion 7.5"
+
+                                                                    href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit7-5">particular
+                                cases</a>)? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.2.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): SCR14</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#script">Go to category: Scripts</a></li>
+                <li class="bas"><a href="#structure">Go to category: Information
+                        structure
+                    </a></li>
+            </ul>
+            <article id="elements" class="thematique">
+                <header>
+                    <h2>Mandatory elements</h2>
+                    <h3>General guidelines</h3>
+                    <p>Check that each Web page has a valid source code
+                        according to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
+                            type</a>, a relevant title and a <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
+                            default human language</a> identification. Check that
+                        tags are not used for presentation only, that changes in
+                        human language and changes in the direction of reading
+                        order are specified.</p>
+                </header>
+                <section>
+                    <h3 id="crit-8-1">Criterion 8.1 [A] Is each Web page defined
+                        by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
+                            type</a>?</h3>
+                    <ul>
+                        <li id="test-8-1-1"> Test 8.1.1: For each Web page, is the
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
+                                type</a> (doctype tag) available?</li>
+                        <li id="test-8-1-2"> Test 8.1.2: For each Web page is the
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
+                                type</a> (doctype tag) valid?</li>
+                        <li id="test-8-1-3"> Test 8.1.3: For each Web page with a
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
+                                type</a> declaration, is this declaration located
+                            before the HTML tag in the source code?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            4.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G134 - G192</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-2">Criterion 8.2 [A] For each Web page, is
+                        the source code <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeValide">valid</a>
+                        according to the specified <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
+                            type</a> (except in <a title="Particular cases for criterion 8.2" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-2">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-8-2-1"> Test 8.2.1: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
+                                type</a> declaration, does the page source code meet
+                            the following conditions (except in <a title="Particular cases for criterion 8.2" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-2">particular cases</a>)?
+                            <ul>
+                                <li> Tags follow the writing rules</li>
+                                <li> Tag nesting is conform</li>
+                                <li> Tag opening and closing are conform</li>
+                                <li> Attributes follow the writing rules</li>
+                                <li> The attribute values follow the writing rules</li>
+                            </ul>
+                        </li>
+                        <li id="test-8.2.2"> Test 8.2.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mDTD">document
+                                type</a> declaration, the page source code must not
+                            contain obsolete elements. Has this rule been
+                            followed (except in <a title="Particular cases for criterion 8.2" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-2">particular cases</a>)?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            4.1.1 - 4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G134 - G192 - H74 - H75 -
+                            H88 - H93 - H94 - F70 - F77 - F62</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-3">Criterion 8.3 [A] On each Web page, is the
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
+                            default human language</a> identifiable?</h3>
+                    <ul>
+                        <li id="test-8-3-1"> Test 8.3.1: For each Web page, does
+                            the <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
+                                default human language</a> identification meet one of
+                            the following conditions?
+                            <ul>
+                                <li> The human language identification (<code>lang</code> and/or
+                                    <code>xml:lang</code> attribute) for the page is provided via the
+                                    HTML element</li>
+                                <li> The human language identification (<code>lang</code> and/or
+                                    <code>xml:lang</code> attribute) for the page is provided via
+                                    each text element or one of the parent elements</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H57</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-4">Criterion 8.4 [A] For each Web page with a
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
+                            default human language</a>, is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeLangue">
+                            language code</a> appropriate?</h3>
+                    <ul>
+                        <li id="test-8-4-1"> Test 8.4.1: For each Web page with a
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
+                                default human language</a>, does the <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeLangue">
+                                language code</a> meet the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeLangue">language
+                                        code</a> is valid</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mCodeLangue">language
+                                        code</a> is appropriate</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H57</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-5">Criterion 8.5 [A] Does each Web page have
+                        a <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitrePage">page
+                            title</a>?</h3>
+                    <ul>
+                        <li id="test-8-5-1"> Test 8.5.1: Does each Web page have a
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitrePage">page
+                                title</a> (<code>title</code> tag)?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G88 - G127 - H25</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-6">Criterion 8.6 [A] For each Web page with a
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitrePage">page
+                            title</a>, is this title relevant?</h3>
+                    <ul>
+                        <li id="test-8-6-1"> Test 8.6.1: For each Web page with a
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitrePage">page
+                                title</a> (<code>title</code> tag), is the content of this tag
+                            relevant? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s):G88 - G127 - F25</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-7">Criterion 8.7 [AA] On each Web page, is
+                        each change in the human language identified via the
+                        source code (except
+                        in <a title="Particular cases for criterion 8.7" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-7">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-8-7-1"> Test 8.7.1: On each Web page, does
+                            each text written in a language differing from the <a href="./RGAA3.0_Glossary_English_version_v1.html#mLangueDefaut">
+                                default human language</a> meet one of the following
+                            conditions (except
+                            in <a title="Particular cases for criterion 8.7" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit8-7">particular cases</a>)?
+                            <ul>
+                                <li> The human language identification is provided via
+                                    the element containing the text</li>
+                                <li> The human language identification is provided via
+                                    one of the parent elements</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H58</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-8">Criterion 8.8 [AA] On each Web page, is
+                        each change in human language relevant?</h3>
+                    <ul>
+                        <li id="test-8-8-1"> Test8.8.1: On each Web page, is each
+                            change in human language identification (lang and/or
+                            xml:lang attribute) technically valid?</li>
+                        <li id="test-8-8-2"> Test 8.8.2: On each Web page, is each
+                            change in human language identification (lang and/or
+                            xml:lang attribute) relevant?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H58</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-9">Criterion 8.9 [A] On each Web page, tags
+                        must not be used <a href="./RGAA3.0_Glossary_English_version_v1.html#mUniquPres">only
+                            for layout</a>. Has this rule been followed?</h3>
+                    <ul>
+                        <li id="test-8-9-1"> Test 8.9.1: On each Web page, tags
+                            must not be used (except <code>div</code>, <code>span</code> and <code>table</code>) <a href="./RGAA3.0_Glossary_English_version_v1.html#mUniquPres">only
+                                for layout</a>. Has this rule been followed? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G115 - H88 - F43 - F92</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-8-10">Criterion 8.10 [A] On each Web page, are
+                        changes in <a href="./RGAA3.0_Glossary_English_version_v1.html#mSensLecture">reading
+                            direction</a> identified?</h3>
+                    <ul>
+                        <li id="test-8-10-1"> Test 8.10.1: On each Web page, does
+                            each text for which the reading direction is different
+                            from the default <a href="./RGAA3.0_Glossary_English_version_v1.html#mSensLecture">reading
+                                direction</a> meet the following conditions?
+                            <ul>
+                                <li> the text is contained in an element with a <code>dir</code>
+                                    attribute</li>
+                                <li> The value of the <code>dir</code> attribute is valid (<code>rtl</code> or
+                                    <code>ltr</code>)</li>
+                                <li> The value of the <code>dir</code> attribute is relevant</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H56</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#elements">Go to category: Mandatory
+                        elements</a></li>
+                <li class="bas"><a href="#presentation">Go to category: Presentation
+                        of information</a></li>
+            </ul>
+            <article id="structure" class="thematique">
+                <header>
+                    <h2>Information structure</h2>
+                    <h3>General guidelines</h3>
+                    <p>Use <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">headings</a>,
+                        landmarks, lists, abbreviations and quotes to structure
+                        information. </p>
+                </header>
+                <section>
+                    <h3 id="crit-9-1">Criterion 9.1 [A] On each Web page, is
+                        information structured by the appropriate use of <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">headings</a>?</h3>
+                    <ul>
+                        <li id="test-9-1-1"> Test 9.1.1: Is there a level 1 <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">heading</a>
+                            (<code>h1</code> tag or a tag with an ARIA
+                            <code>role="heading"</code> associated to an <code>aria-level="1"</code>
+                            property) on each Web page?</li>
+                        <li id="test-9-1-2"> Test 9.1.2: On each Web page, is the
+                            hierarchy between the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">headings</a>
+                            (<code>h1</code> to <code>h6</code> tags or tags with an ARIA
+                            <code>role="heading"</code> associated to an <code>aria-level</code> property)
+                            relevant?</li>
+                        <li id="test-9-1-3">Test 9.1.3: On each Web page, when a
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">heading</a>
+                            (<code>h1</code> to <code>h6</code> tag or a tag with an ARIA
+                            <code>role="heading"</code> associated to an <code>aria-level</code> property),
+                            is necessary to structure information, is this heading available?</li>
+                        <li id="test-9-1-4"> Test 9.1.4: On each Web page, is each
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mTitre">heading</a>
+                            (<code>h1</code> to <code>h6</code> tag or a tag with an ARIA
+                            <code>role="heading"</code> associated to an <code>aria-level</code> property)
+                            relevant?</li>
+                    </ul>
+
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-1">technical note about the ARIA <code>heading</code> role and <code>h1</code> headings</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.3.1 - 2.4.1 - 2.4.6 - 2.4.10</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H69 - G115 - G130 - H42 -
+                            G141 - ARIA4 - ARIA12</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-9-2">Criterion 9.2 [A] On each Web page, is the
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mDocumentOutline">document outline</a> coherent?</h3>
+                    <ul>
+                        <li id="test-9-2-1"> Test 9.2.1: On each Web page, does
+                            the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDocumentOutline">document outline</a> meet the following conditions?
+                            <ul>
+                                <li>the <a href="./RGAA3.0_Glossary_English_version_v1.html#PageHeader">page header</a> is identified
+                                    via a <code>header</code> tag</li>
+                                <li>the main and secondary <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation areas</a> are identified via a <code>nav</code> tag</li>
+                                <li>the <code>nav</code> tag is used only to identify
+                                    the main and secondary <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation areas</a></li>
+                                <li>the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> is identified
+                                    via a <code>main</code> tag</li>
+                                <li>the <code>main</code> tag is unique in the page</li>
+                                <li>the page <a href="./RGAA3.0_Glossary_English_version_v1.html#mFooter">footer</a> area is identified
+                                    via a <code>footer</code> tag</li>
+                            </ul>
+                        </li>
+                        <li id="test-9-2-2"> Test 9.2.2: On each Web page, is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDocumentOutline">document outline</a> coherent?</li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-2">technical note about the document outline</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G115 - ARIA11</p>
+
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-9-3">Criterion 9.3 [A] On each Web page, is
+                        each <a href="./RGAA3.0_Glossary_English_version_v1.html#mListes">list</a>
+                        structured  appropriately?</h3>
+                    <ul>
+                        <li id="test-9-3-1"> Test 9.3.1: On each Web page, does
+                            information grouped in an unordered <a href="./RGAA3.0_Glossary_English_version_v1.html#mListes">list</a>
+                            meet one of the following conditions?
+                            <ul>
+                                <li>the list uses the <code>ul</code> and <code>li</code> tags</li>
+                                <li>the list
+                                    uses the ARIA roles <code>list</code> and <code>listitem</code></li>
+                            </ul>
+                        </li>
+                        <li id="test-9-3-2"> Test 9.3.2: On each Web page, does
+                            information grouped in ordered <a href="./RGAA3.0_Glossary_English_version_v1.html#mListes">lists</a>
+                            meet one of the following conditions?
+                            <ul>
+                                <li>the list uses the <code>ol</code> and <code>li</code> tags</li>
+                                <li>the list
+                                    uses the ARIA roles <code>list</code> and <code>listitem</code>
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-9-3-3"> Test 9.3.3: On each Web page, does
+                            information grouped in definition <a href="./RGAA3.0_Glossary_English_version_v1.html#mListes">lists</a>
+                            use the <code>dl</code> and <code>dt</code>/<code>dd</code> tags? </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-3">technical note about the <code>list</code> and <code>listitem</code> roles</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G153 - G115 - H40 - H48 -
+                            H97 - F2</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-9-4">Criterion 9.4
+                        [AAA] On each Web page, does the first occurence of each <a
+
+                            href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                        help to know its meaning?</h3>
+                    <ul>
+                        <li id="test-9-4-1"> Test 9.4.1:
+                            On each Web page, does the first occurence of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                            meet one of the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                                    is provided with its meaning as an adjacent link</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                                    is implemented via a link referring to a page or a
+                                    location in the page, providing its meaning</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                                    is included in a link with a <code>title</code> attribute
+                                    providing its meaning</li>
+                                <li> The meaning of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                                    is available in a glossary on the website</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                                    is implemented via an <code>abbr</code> tag with a <code>title</code> attribute
+                                    providing its meaning</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-4">technical note about the ARIA role <code>definition</code></a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G55 - G70 - G97 - G102 -
+                            H28</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-9-5">Criterion 9.5
+                        [AAA] On each Web page, is the meaning of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                        relevant?</h3>
+                    <ul>
+                        <li id="test-9-5-1"> Test 9.5.1:
+                            On each Web page, is the meaning of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mAbbr">abbreviation</a>
+                            relevant?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G55 - G70 - G97 - G102 -
+                            H28</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-9-6">Criterion 9.6
+                        [A] On each Web page, is each quotation identified
+                        properly?</h3>
+                    <ul>
+                        <li id="test-9-6-1"> Test 9.6.1:
+                            On each Web page, does each short quotation use a <code>q</code> tag?</li>
+                        <li id="test-9-6-2"> Test 9.6.2:
+                            On each Web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBlocCite">long
+                                quotation</a> use a <code>blockquote</code> tag?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G115 - H49 - F2</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#structure">Go to category: Information structure</a></li>
+                <li class="bas"><a href="#formulaire">Go to category: Forms</a></li>
+            </ul>
+            <article id="presentation" class="thematique">
+                <header>
+                    <h2>Presentation of information </h2>
+                    <h3>General guidelines</h3>
+                    <p>Use <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
+                            sheets</a> to control information presentation. Check
+                        for the effect of font size increasing on readability.
+                        Ensure that links can be correctly identified, that
+                        focus is specified, that line spacing is suffiscient,
+                        and give the user the ability to control text
+                        justification. Ensure that hidden texts are rendered
+                        properly and that information is not conveyed only by an
+                        element's shape, size or location.</p>
+                </header>
+
+                <section>
+                    <h3 id="crit-10-1">Criterion 10.1 [A] In the <a href="./RGAA3.0_Glossary_English_version_v1.html#mSiteWeb">Web
+                            site</a>, are <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
+                            sheets</a> used to control <a href="./RGAA3.0_Glossary_English_version_v1.html#mPresInfo">information
+                            presentation</a>?</h3>
+                    <ul>
+                        <li id="test-10-1-1"> Test 10.1.1: On each Web page, tags
+                            used for <a href="./RGAA3.0_Glossary_English_version_v1.html#mPresInfo">information
+                                presentation</a> must not be available in the source
+                            code. Has this rule been followed?</li>
+                        <li id="test-10-1-2"> Test 10.1.2: On each Web page,
+                            attributes used for <a href="./RGAA3.0_Glossary_English_version_v1.html#mPresInfo">information
+                                presentation</a> must not be available in the source
+                            code. Has this rule been followed?</li>
+                        <li id="test-10-1-3"> Test 10.1.3: On each Web page, does
+                            the use of white spaces meet the following conditions?
+                            <ul>
+                                <li>White spaces characters are not used to control spacing within a
+                                    word</li>
+                                <li>White spaces characters are not used to format tables in plain text content</li>
+                                <li>White spaces characters are not used to create multiple columns in plain text content</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.3.1 - 1.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G140 - F32 - F33 - F34 -
+                            C6 - C8 - C18 - C22 - F48</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-2">Criterion 10.2 [A] On each Web page, is <a
+                            href="./RGAA3.0_Glossary_English_version_v1.html#mVisibleContent">visible
+                            content</a> still available when <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
+                            sheets</a> or images are disabled?</h3>
+                    <ul>
+                        <li id="test-10-2-1"> Test 10.2.1: On each Web page, is
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mVisibleContent">visible content</a> still available when <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
+                                sheets</a> are disabled?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.1.1 - 1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G140 - F3 - F87</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-3">Criterion 10.3 [A] On each Web page, is
+                        information still <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">understandable</a>
+                        when <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
+                            sheets</a> are disabled?</h3>
+                    <ul>
+                        <li id="test-10-3-1">Test 10.3.1: On each Web page, is
+                            information still <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">understandable</a>
+                            when <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
+                                sheets</a> are disabled?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.3.2 - 2.4.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): F1 - G59</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-4">Criterion 10.4 [AA] On each Web page, is
+                        text still readable when <a href="./RGAA3.0_Glossary_English_version_v1.html#mTailleCaractere">character
+                            size</a> is increased until at least 200%?</h3>
+                    <ul>
+                        <li id="test-10-4-1"> Test 10.4.1: In the <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
+                                sheets</a> of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mSiteWeb">website</a>,
+                            non relative units (pt, pc, mm, cm, in) must not be used
+                            for the media types screen, tv, handheld, projection.
+                            Has this rule been followed?</li>
+                        <li id="test-10-4-2"> Test 10.4.2: In the <a href="./RGAA3.0_Glossary_English_version_v1.html#mFeuilleStyle">style
+                                sheets</a> of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mSiteWeb">website</a>,
+                            for the media types screen,
+                            tv, handheld, projection, do font sizes use
+                            relative units only?</li>
+                        <li id="test-10-4-3"> Test 10.4.3: On each Web page,
+                            increasing the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTailleCaractere">character
+                                size</a> up to 200% must not cause loss of
+                            information. Has this rule been followed? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.4.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G146 - F80 - F69 - C14 -
+                            C12 - C13 - C17 - C28 - G179 - SCR34</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-5">Criterion 10.5 [AA] On each Web page, are
+                        CSS declarations for background and foreground colors
+                        appropriate?</h3>
+                    <ul>
+                        <li id="test-10-5-1"> Test 10.5.1: On each Web page, for
+                            each element that may contain text, is the CSS
+                            declaration for foreground color accompanied by a
+                            background color declaration at least, inherited from a
+                            parent element?</li>
+                        <li id="test-10-5-2"> Test 10.5.2: On each Web page, for
+                            each element that may contain text, is the CSS
+                            declaration for background color accompanied by a
+                            foreground color declaration at least, inherited from a
+                            parent element?</li>
+                        <li id="test-10-5-3"> Test 10.5.3: On each Web page, for
+                            each element that may contain text, if an image is used
+                            to provide a background color via CSS, is there a
+                            corresponding background color declaration, at least,
+                            inherited from a parent element? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.4.3 - 1.4.6 - 1.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): F24</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-6">Criterion 10.6 [A] On each Web page, can
+                        each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienNature">link
+                            whose nature is not obvious</a> be distinguished from
+                        the surrounding text?</h3>
+                    <ul>
+                        <li id="test-10-6-1"> Test 10.6.1: On each Web page, does
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienTexte">text
+                                link</a> indicated through color alone, and whose nature is
+                            not obvious, have a contrast ratio of 3:1 or greater
+                            with the surrounding text? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.4.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G183 - F73</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-7">Criterion 10.7 [A] On each Web page, is
+                        the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPriseFocus">focus
+                        </a> visible for each element that receives focus?</h3>
+                    <ul>
+                        <li id="test-10-7-1">Test 10.7.1: For each element
+                            receiving focus, the browser default visual cue must not
+                            be removed (CSS property outline, outline-color,
+                            outline-width, outline-style). Has this rule been
+                            followed? </li>
+                        <li id="test-10-7-2"> Test 10.7.2: For each element
+                            receiving focus, the browser default visual cue must not
+                            be degraded (CSS property outline-color). Has this rule
+                            been followed?</li>
+                        <li id="test-10.7.3"> Test 10.7.3: Does each link inside a
+                            text, indicated through color alone, meet the conditions
+                            below?
+                            <ul>
+                                <li>An additional visual cue, other than color, is
+                                    provided when the user tabs to the link with the
+                                    keyboard</li>
+                                <li>An additional visual cue, other than color, is
+                                    provided when the user points to the link (hovers)
+                                    with the mouse</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.4.1 - 2.4.7</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G149 - G183 - F73 - F78 -
+                            G165 - C15 - G195 - SCR31</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-8">Criterion 10.8 [AAA] On each Web page,
+                        can the user specify the background and foreground colors?</h3>
+                    <ul>
+                        <li id="test-10-8-1"> Test 10.8.1: For each block of text
+                            inside an HTML element, can the background color be
+                            specified by the user?</li>
+                        <li id="test-10-8-2"> Test 10.8.2: For each block of text
+                            inside an HTML element, can the foreground color be
+                            specified by the user?</li>
+                        <li id="test-10-8-3"> Test 10.8.3: For each block of text
+                            inside an <code>object</code>, embed, <code>svg</code>
+                            or <code>canvas</code> tag, can the background color be
+                            specified by the user?</li>
+                        <li id="test-10-8-4"> Test 10.8.4: For each block of text
+                            inside an <code>object</code>, embed, <code>svg</code>
+                            or <code>canvas</code> tag, can the foreground color be
+                            specified by the user? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G156 - G175</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-9">Criterion 10.9 [AAA] for each Web page,
+                        text must not be fully justified. Has this rule been followed?</h3>
+                    <ul>
+                        <li id="test-10-9-1"> Test 10.9.1: Does each Web page meet
+                            one of the following conditions?
+                            <ul>
+                                <li>The text is not fully justified</li>
+                                <li>The user can remove the
+                                    full justification of text, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): F88 - G166 - G172</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-10">Criterion 10.10 [AAA] For each Web page,
+                        on a full-screen window and with a font size of 200%, is
+                        each block of text still readable without the use of
+                        horizontal scrolling?</h3>
+                    <ul>
+                        <li id="test-10-10-1"> Test 10.10.1: On each Web page,
+                            does increasing the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTailleCaractere">text
+                                size</a> up to 200% meet one of the following
+                            conditions?
+                            <ul>
+                                <li> In a full-screen window, the use of horizontal
+                                    scrolling is not required to read a block of text</li>
+                                <li>The user can display, via a provided mechanism, a version of the content where the use of horizontal
+                                    scrolling is not required to read a block of text, in a
+                                    full-screen window</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G146 - G206 - C19 - C24 -
+                            C28</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-11">Criterion 10.11 [AAA] For each Web page,
+                        is the length of lines of text equal to 80 characters or
+                        less (except in <a title="Particular cases for criterion 10.11" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit10-11">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-10-11-1"> Test 10.11.1: For each Web page,
+                            does each line of text meet one of the following
+                            conditions (except in <a title="Particular cases for criterion 10.11"
+
+                                                     href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit10-11">particular cases</a>)?
+                            <ul>
+                                <li> The length of each line of text is equal to 80
+                                    characters or less</li>
+                                <li> The user can reduce the length of each line of
+                                    text, down to 80 characters or less, when resizing
+                                    the browser window</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G204 - C20</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-12">Criterion 10.12 [AAA] For each Web page,
+                        is line and paragraph spacing sufficient?</h3>
+                    <ul>
+                        <li id="test-10-12-1"> Test 10.12.1: For each Web page,
+                            does each block of text meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The line spacing is 1.5 times the text size, or
+                                    more</li>
+                                <li> The user can increase the line spacing
+                                    to at least 1.5 times the text size, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                        <li id="test-10-12-2"> Test 10.12.2: For each Web page,
+                            does each block of text meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The spacing between two paragraphs is 1.5 times
+                                    the line spacing, or more</li>
+                                <li>The user can increase the spacing between two paragraphs
+                                    to at least 1.5 times the line spacing, via a provided mechanism</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G188 - C21</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-13">Criterion 10.13 [A] For each Web page,
+                        are <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
+                            texts</a> rendered properly by assistive technologies?</h3>
+                    <ul>
+                        <li id="test-10-13-1">Test 10.13.1: On each Web page, does
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
+                                text</a> meet one of the following conditions?
+                            <ul>
+                                <li>The text is not intended to be rendered by
+                                    assistive technologies</li>
+                                <li> The text is made visible on user action on the
+                                    element itself or on an element before the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
+                                        text</a></li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
+                                        text</a> is part of a user interface
+                                    component ruled by the ARIA API, which manages the
+                                    displayed or hidden status of the content</li>
+                            </ul>
+                        </li>
+                        <li id="test-10-13-2">Test
+                            10.13.2: On each Web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
+                                text</a> using an ARIA property <code>aria-hidden</code> meet one
+                            of the following conditions?
+                            <ul>
+                                <li>The text is not intended
+                                    to be rendered by assistive technologies</li>
+                                <li>The value of the ARIA
+                                    property <code>aria-hidden</code> matches the visible or hidden
+                                    status of the text
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-10-13-3">Test
+                            10.13.3: On each Web page, does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
+                                text</a> using the <code>hidden</code> attribute  meet one of the
+                            following conditions?
+                            <ul>
+
+                                <li>The text is not intended
+                                    to be rendered by assistive technologies</li>
+
+                                <li> The text is made
+                                    visible on user action on the element itself or on
+                                    an element before the <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
+                                        text</a></li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mTexteCache">hidden
+                                        text</a> is part
+                                    of a user interface component ruled by the ARIA
+                                    API, which manages the displayed or hidden status
+                                    of the content</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit10-13">technical note about the <code>aria-hidden</code> property and the <code>hidden</code> attribute</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            4.1.2 - 1.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G57</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-14">Criterion 10.14 [A] On each Web page,
+                        information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been followed?</h3>
+                    <ul>
+                        <li id="test-10-14-1"> Test 10.14.1: On each Web page, for
+                            each text or set of text, information must not be
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule
+                            been followed?</li>
+                        <li id="test-10-14-2"> Test 10.14.2: On each Web page, for
+                            each image or set of images, information must not be
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule
+                            been followed?</li>
+                        <li id="test-10-14-3"> Test 10.14.3: On each Web page, for
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a>, information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been followed?</li>
+                        <li id="test-10-14-4"> Test 10.14.4: On each Web page, for
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                                time-based media</a>, information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been
+                            followed?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.4.1 - 1.3.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G96 - G111 - G140 - F14 -
+                            F26</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-10-15">Criterion 10.15 [A] On each Web page,
+                        information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been implemented in a
+                        relevant way?</h3>
+                    <ul>
+                        <li id="test-10-15-1"> Test 10.15.1: On each Web page, for
+                            each text or set of text, information must not be
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule
+                            been implemented in a relevant way?</li>
+                        <li id="test-10-15-2"> Test 10.15.2: On each Web page, for
+                            each image or set of images, information must not be
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule
+                            been implemented in a relevant way?</li>
+                        <li id="test-10-15-3"> Test 10.15.3: On each Web page, for
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaTemp">time-based
+                                media</a>, information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been implemented
+                            in a relevant way?</li>
+                        <li id="test-10-15-4"> Test 10.15.4: On each Web page, for
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mMediaNoTemp">non
+                                time-based media</a>, information must not be <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoShape">conveyed by shape, size or location</a> alone. Has this rule been
+                            implemented in a relevant way?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.4.1 - 1.3.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G96 - G111 - G140 - F14 -
+                            F26</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#presentation">Go to category: Presentation
+                        of information</a></li>
+                <li class="bas"><a href="#navigation">Go to category: Navigation</a></li>
+            </ul>
+            <article id="formulaire" class="thematique">
+                <header>
+                    <h2>Forms</h2>
+                    <h3>General guidelines</h3>
+                    <p>For each form, associate each control with its label,
+                        group controls in similar blocks of information,
+                        structure selection lists in a consistent way, give each
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mBtnForm">button</a>
+                        an explicit label. Check that input help is available,
+                        ensure that the <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleSaisie">input
+                            control</a> is accessible and that the user can
+                        control financial, legal or personal data.</p>
+                </header>
+                <section>
+                    <h3 id="crit-11-1">Criterion 11.1 [A] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
+                            field</a> have a <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>?</h3>
+                    <ul>
+                        <li id="test-11-1-1"> Test 11.1.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
+                                field</a> meet one of the following conditions?
+                            <ul>
+                                <li> The form field has a <code>title</code> attribute</li>
+                                <li> A <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>
+                                    (<code>label</code> tag) is associated with the form field</li>
+                                <li>The form field has an
+                                    <code>aria-label</code> property</li>
+                                <li>The form field has an
+                                    <code>aria-labelledby</code> property that references an
+                                    identified chunk of text</li>
+                            </ul>
+                        </li>
+                        <li id="test-11-1-2">Test 11.1.2: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
+                                field</a> that is associated with a label (<code>label</code> tag),
+                            meet the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
+                                        field</a> has an <code>id</code> attribute</li>
+                                <li> The value of the <code>id</code> attribute is unique</li>
+                                <li>The <code>label</code> tag has a for
+                                    attribute</li>
+                                <li>The value of the for
+                                    attribute matches the value of the corresponding
+                                    form field <code>id</code> attribute </li>
+                            </ul>
+                        </li>
+                        <li id="test-11-1-3">Test
+                            11.1.3: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
+                                field</a> associated with a label, via the ARIA
+                            <code>aria-labelledby</code> property, meet the following
+                            conditions?
+                            <ul>
+                                <li> The label has an <code>id</code>
+                                    attribute</li>
+                                <li>The value of the <code>id</code>
+                                    attribute is unique</li>
+                                <li> The value of the ARIA
+                                    <code>aria-labelledby</code> property matches the value of the
+                                    label <code>id</code> attribute</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.3.1 - 2.4.6 - 3.3.2 - 4.1.2 </p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H44 - H65 - G82 - G131 -
+                            ARIA6 - ARIA9 - ARIA16 - ARIA14 - F17 - F82 - F86 - F68</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-2">Criterion 11.2 [A] Is each label that is
+                        associated with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
+                            field</a> relevant?</h3>
+                    <ul>
+                        <li id="test-11-2-1"> Test 11.2.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>
+                            (<code>label</code> tag) describe the exact function of the
+                            associated <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
+                                field</a>?</li>
+                        <li id="test-11-2-2"> Test 11.2.2: Does each <code>title</code>
+                            attribute describe the exact function of the
+                            associated <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form
+                                field</a>? </li>
+                        <li id="test-11-2-3"> Test 11.2.3: Does each label
+                            implemented via the ARIA <code>aria-label</code> property describe the exact function of the associated <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form  field</a>? </li>
+                        <li id="test-11-2-4"> Test 11.2.4: Does each label
+                            implemented via the ARIA <code>aria-labelledby</code> property describe the exact function of the associated <a href="./RGAA3.0_Glossary_English_version_v1.html#mChpSaisie">form field</a>?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            2.4.6 - 3.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H44 - H65 - G182 - G131 -
+                            ARIA6 - ARIA9 - ARIA16 - ARIA14</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-3">
+                        Criterion 11.3 [AA] On a given page, or set of pages, all form fields with similar functions must have consistent  <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">labels</a>. Has this rule been followed?</h3>
+                    <ul>
+                        <li id="test-11-3-1">
+                            Test 11.3.1: On a given page, all form fields with similar functions must have consistent  <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">labels</a>. Has this rule been followed?
+                        </li>
+
+                        <li id="test-11-3-2">
+                            Test 11.3.2: On a given set of pages, all form fields with similar functions must have consistent  <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">labels</a>. Has this rule been followed?
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+                        <p>WCAG 2.0 success criterion: 3.2.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): F31</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-4">Criterion 11.4 [A] In each form, are each
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>
+                        and its related control positioned next to each other?</h3>
+                    <ul>
+                        <li id="test-11-4-1"> Test 11.4.1: In each form, are each
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mEtiquette">label</a>
+                            and its related control positioned next to each other?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G162</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-5">Criterion 11.5 [A] In each form, is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoMNature">information of same nature</a> grouped together, if necessary?</h3>
+                    <ul>
+                        <li id="test-11-5-1">Test 11.5.1: In each form, is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mInfoMNature">information of same nature</a> grouped together via a <code>fieldset</code> tag, if necessary? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.3.1 - 3.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H71</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-6">Criterion 11.6 [A] In each form, does
+                        each form field grouping have a legend?</h3>
+                    <ul>
+                        <li id="test-11-6-1"> Test 11.6.1: Is each form field
+                            grouping (<code>fieldset</code> tag) followed by a legend (<code>legend</code>
+                            tag) in the source code? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.3.1 - 3.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H71</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-7">Criterion 11.7 [A] In each form, is each
+                        legend, related to a form field grouping, relevant?</h3>
+                    <ul>
+                        <li id="test-11-7-1"> Test 11.7.1: In each form, is each
+                            legend (<code>legend</code> tag), related to a form field grouping
+                            (<code>fieldset</code> tag), relevant? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H71</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-8">Criterion 11.8 [A] In each form, is each
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mListeChoix">selection
+                            list</a> structured in a relevant way?</h3>
+                    <ul>
+                        <li id="test-11-8-1"> Test 11.8.1: In each form, are for
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mListeChoix">selection
+                                list</a> (<code>select</code> tag) items grouped together with an
+                            <code>optgroup</code> tag, if necessary?</li>
+                        <li id="test-11-8-2"> Test 11.8.2: In each <a href="./RGAA3.0_Glossary_English_version_v1.html#mListeChoix">selection
+                                list</a> (<code>select</code> tag), does each list item grouping
+                            (<code>optgroup</code> tag) have a <code>label</code> attribute?</li>
+                        <li id="test-11-8-3"> Test 11.8.3: For each list item
+                            grouping (<code>optgroup</code> tag) with a <code>label</code> attribute, is the
+                            content of the <code>label</code> attribute relevant?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H85</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-9">Criterion 11.9 [A] In each form, is the
+                        text of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBtnForm">button</a>
+                        relevant?</h3>
+                    <ul>
+                        <li id="test-11-9-1">Test 11.9.1: In each form, does the
+                            text of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBtnForm">button</a>
+                            meet one of the following conditions?
+                            <ul>
+                                <li> The content of the <code>value</code> attribute of the form
+                                    buttons of type <code>submit</code>, <code>reset</code> or <code>button</code> is relevant</li>
+                                <li> The content of the <code>&lt;button&gt;</code> tag is relevant</li>
+                                <li> The content of the <code>title</code>
+                                    attribute is relevant</li>
+                                <li>The content of the ARIA
+                                    property <code>aria-label</code> is relevant</li>
+                            </ul>
+                        </li>
+                        <li id="test-11-9-2">Test
+                            11.9.2: In each form, does the text of each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBtnForm">button</a>
+                            implemented via an ARIA property <code>aria-labelledby</code> meet
+                            the following conditions?
+                            <ul>
+
+                                <li> The referenced chunk of
+                                    text has an <code>id</code> attribute</li>
+
+                                <li> The value of the <code>id</code>
+                                    attribute is unique</li>
+
+                                <li> The value of the ARIA
+                                    property <code>aria-labelledby</code> matches the value of the
+                                    <code>id</code> attribute of the chunk of text</li>
+                                <li>The chunk of text is
+                                    relevant</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H36 - H91 - ARIA6 - ARIA9
+                            - ARIA16 - ARIA14</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-10">Criterion 11.10 [A] In each form, is the
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleSaisie">input
+                            control</a> used in a relevant way?</h3>
+                    <ul>
+                        <li id="test-11-10-1"> Test
+                            11.10.1: For each form, do mandatory fields
+                            indications meet one of the following conditions?
+                            <ul>
+                                <li>The
+                                    mandatory field indication is provided via a chunk
+                                    of text before the form field</li>
+                                <li>The
+                                    mandatory field indication is provided via a
+                                    "<code>required</code>" attribute</li>
+                                <li>The
+                                    mandatory field indication is provided via an
+                                    <code>aria-required</code> ARIA property</li>
+                                <li>The
+                                    mandatory field indication is provided via the label
+                                    (<code>label</code> tag, or <code>title</code> attribute, or <code>aria-label</code>
+                                    property, or labelling chunk of text identified via
+                                    the <code>aria-labelledby</code> property) of the form field</li>
+                                <li>The
+                                    mandatory field indication is provided via a chunk
+                                    of text, tied to the form field via the
+                                    <code>aria-describedby</code> ARIA property</li>
+                            </ul>
+                        </li>
+
+                        <li id="test-11-10-2"> Test
+                            11.10.2: Each mandatory field indication based on the
+                            ARIA properties <code>aria-label</code>, <code>aria-required</code>, or the
+                            "<code>required</code>" attribute, must have an explicit visual cue
+                            in its label (<code>label</code> tag) or in a chunk of text tied to
+                            the form field via the ARIA property <code>aria-describedby</code>
+                            or <code>aria-labelledby</code>. Has this rule been followed?</li>
+
+                        <li id="test-11-10-3">Test
+                            11.10.3: Does each mandatory field indication provided
+                            via a chunk of text tied by an ARIA property
+                            <code>aria-describedby</code> or <code>aria-labelledby</code> meet the following
+                            conditions?
+                            <ul>
+                                <li> The referenced chunk of
+                                    text has an <code>id</code> attribute</li>
+                                <li> The value of the <code>id</code> attribute is unique</li>
+                                <li> The value of the ARIA
+                                    property <code>aria-describedby</code> or <code>aria-labelledby</code> matches
+                                    the value of the <code>id</code> attribute
+                                </li>
+                            </ul>
+                        </li>
+                        <li id="test-11-10-4">Test
+                            11.10.4: For each form, do the input errors meet one
+                            of the following conditions?
+                            <ul>
+                                <li> The input error message
+                                    is provided via the label (<code>label</code> tag, or <code>title</code>
+                                    attribute, or <code>aria-label</code> property, or labelling
+                                    chunk of text identified via the <code>aria-labelledby</code>
+                                    property) of the form field</li>
+                                <li>The input error message is
+                                    provided via a chunk of text before the form field</li>
+                                <li>The form field has a type
+                                    that automatically generates an input error message</li>
+                                <li>The input error message is
+                                    provided via a chunk of text tied to the form field
+                                    via the ARIA property <code>aria-describedby</code></li>
+                                <li>The input error is
+                                    signaled via the ARIA property <code>aria-invalid</code></li>
+                            </ul>
+                        </li>
+                        <li id="test-11-10-5">Test 11.10.5: Each input
+                            error indication based on the ARIA properties
+                            <code>aria-label</code> or <code>aria-invalid</code> must have an explicit
+                            visual cue in the label (<code>label</code> tag) or in a chunk of
+                            text tied to the form field via the ARIA property
+                            <code>aria-describedby</code> or <code>aria-labelledby</code>. Has this rule
+                            been followed?
+                        </li>
+                        <li id="test-11-10-6">Test
+                            11.10.6: Does each input error indication provided via
+                            a chunk of text tied by an ARIA property
+                            <code>aria-describedby</code> or <code>aria-labelledby</code> meet the following
+                            conditions?
+                            <ul>
+                                <li> The referenced chunk of
+                                    text has an <code>id</code> attribute</li>
+                                <li> The value of the <code>id</code>
+                                    attribute is unique</li>
+                                <li> The value of the ARIA
+                                    property <code>aria-describedby</code> or <code>aria-labelledby</code> matches
+                                    the value of the <code>id</code> attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-11-10-7"> Test
+                            11.10.7: For each form, does each mandatory field meet
+                            one of the following conditions?
+                            <ul>
+                                <li>The data
+                                    type and/or format is provided, if necessary, via
+                                    the field label (<code>label</code> tag, or <code>title</code> attribute, or
+                                    <code>aria-label</code> property, or labelling chunk of text
+                                    identified via the <code>aria-labelledby</code> property)</li>
+                                <li>The data
+                                    type and/or format is provided, if necessary, via a
+                                    chunk of text before the form field </li>
+                                <li>The data
+                                    type and/or format is provided via a chunk of text,
+                                    tied to the form field via the <code>aria-describedby</code> ARIA
+                                    property</li>
+                            </ul>
+                        </li>
+                        <li id="test-11-10-8"> Test
+                            11.10.8: Each data type and/or format indication based
+                            on the ARIA properties <code>aria-label</code> must have an
+                            explicit visual cue in its label (<code>label</code> tag) or in a
+                            chunk of text tied to the form field via the ARIA
+                            property <code>aria-describedby</code> or <code>aria-labelledby</code>. Has this
+                            rule been followed?</li>
+                        <li id="test-11-10-9">Test
+                            11.10.9: Does each data type and/or format indication
+                            provided via a chunk of text tied by an ARIA property
+                            <code>aria-describedby</code> or <code>aria-labelledby</code> meet the following
+                            conditions?
+                            <ul>
+                                <li> The referenced chunk of
+                                    text has an <code>id</code> attribute</li>
+                                <li> The value of the <code>id</code>
+                                    attribute is unique</li>
+                                <li> The value of the ARIA
+                                    property <code>aria-describedby</code> or <code>aria-labelledby</code> matches
+                                    the value of the <code>id</code> attribute</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            3.3.1 - 3.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G83 - G84 - G85 - G89 -
+                            G184 - H44 - H89 - H90 - F81 - SCR18 - SCR32 - ARIA1 -
+                            ARIA2 - ARIA6 - ARIA9 - ARIA16 - ARIA21</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-11">Criterion 11.11 [AA] In each form, is <a
+
+                            href="./RGAA3.0_Glossary_English_version_v1.html#mControleSaisie">input
+                            control</a> accompanied, if necessary,
+                        by suggestions helping with the correction of input
+                        errors?</h3>
+                    <ul>
+                        <li id="test-11-11-1"> Test 11.11.1: For each form, for
+                            each input error, are each <a href="./RGAA3.0_Glossary_English_version_v1.html#mTypeDonnes">data
+                                types and formats</a> suggested, if necessary?</li>
+                        <li id="test-11-11-2"> Test 11.11.2: For each form, for
+                            each input error, are examples for expected values
+                            suggested, if necessary?
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit11-11">technical note about automatic format controls in HTML5</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.3.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G84 - G85 - G89 - G177 -
+                            H89</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-12">Criterion 11.12 [AA] For each form, can
+                        financial, legal or personal data be changed, updated or
+                        retrieved by the user?</h3>
+                    <ul>
+                        <li id="test-11-12-1"> Test 11.12.1: For each form, do the
+                            input of financial, legal or personal data meet one of
+                            the following conditions?
+                            <ul>
+                                <li> The user can change or reset the data, and cancel
+                                    actions made on these data after they have been
+                                    entered</li>
+                                <li> The user can check and modify data before form
+                                    submission</li>
+                                <li> An explicit confirmation mechanism, via a form
+                                    field or an additional step, is available</li>
+                            </ul>
+                        </li>
+                        <li id="test-11-12-2">Test 11.12.2: For each form, does
+                            the deletion of financial, legal or personal data meet
+                            one of the following conditions?
+                            <ul>
+                                <li> The user can recover data that have been
+                                    deleted, via a provided mechanism</li>
+                                <li> An explicit mechanism confirming deletion, via a
+                                    form field or an additional step, is available </li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.3.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G98 - G99 - G155 - G164 -
+                            G168</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-13">Criterion 11.13 [AAA] For each form, can
+                        all data be changed, updated or recovered by the user?</h3>
+                    <ul>
+                        <li id="test-11-13-1"> Test 11.13.1: For each form, does
+                            data input meet one of the following conditions?
+                            <ul>
+                                <li> The user can change or cancel data and actions on
+                                    this data after it has been entered</li>
+                                <li> The user can check and correct data before form
+                                    submission</li>
+                                <li> An explicit confirmation mechanism, via a form
+                                    field or an additional step, is available </li>
+                            </ul>
+                        </li>
+                        <li id="test-11-13-2"> Test 11.13.2: For each form, does
+                            data deletion meet one of the following conditions?
+                            <ul>
+                                <li> The user can recover data that have been
+                                    deleted, via a provided mechanism</li>
+                                <li> An explicit mechanism confirming deletion, via a
+                                    form field or an additional step, is available </li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.3.6</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G98 - G99 - G155 - G164-
+                            G168</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-14">Criterion 11.14 [AAA] For each form, is
+                        input assistance available?</h3>
+                    <ul>
+                        <li id="test-11-14-1"> Test 11.14.1: Does each form meet
+                            one of the following conditions?
+                            <ul>
+                                <li> There is a link to a help page</li>
+                                <li>Indications before the form are available</li>
+                                <li>Indications before form fields are available</li>
+                                <li>Indications are provided
+                                    via the form field label (<code>label</code> tag, or title
+                                    attribute, or <code>aria-label</code> property, or labelling
+                                    chunk of text identified via the <code>aria-labelledby</code>
+                                    property)</li>
+                                <li>Indications are provided
+                                    via a chunk of text, tied to the form field via
+                                    the <code>aria-describedby</code> ARIA property</li>
+                                <li>an assistant is available</li>
+                            </ul>
+                        </li>
+                        <li id="test-11-14-2">Test
+                            11.14.2: Each indication based on the ARIA property
+                            <code>aria-label</code> must have an explicit visual cue. Has this
+                            rule been followed?</li>
+                        <li id="test-11-14-3">Test
+                            11.14.3: Does each indication provided via a chunk of
+                            text tied by an ARIA property <code>aria-describedby</code> meet
+                            the following conditions?
+                            <ul>
+                                <li> The referenced chunk of
+                                    text has an <code>id</code> attribute</li>
+                                <li> The value of the <code>id</code>
+                                    attribute is unique</li>
+                                <li> The value of the ARIA
+                                    property <code>aria-describedby</code> matches the value of the <code>id</code>
+                                    attribute</li>
+                            </ul>
+                        </li>
+                        <li id="test-11-14-4">Test 11.14.4: Does each field of
+                            type text meet one of the following conditions, if
+                            necessary?
+                            <ul>
+                                <li> A spell checking tool is available</li>
+                                <li>Input suggestions are
+                                    provided before the form field</li>
+                                <li>Input suggestions are
+                                    provided via the form field label (<code>label</code> tag, or
+                                    <code>title</code> attribute, or <code>aria-label</code> property, or
+                                    labelling chunk of text identified via the
+                                    <code>aria-labelledby</code> property)</li>
+                                <li>Input
+                                    suggestions are provided via a chunk of text, tied
+                                    to the form field via the <code>aria-describedby</code> ARIA
+                                    property</li>
+                            </ul>
+                        </li>
+
+                        <li id="test-11-14-5">Test 11.14.5: Each input
+                            suggestion based on the ARIA property <code>aria-label</code> must
+                            have an explicit visual cue. Has this rule been
+                            followed?</li>
+                        <li id="test-11-14-6">Test
+                            11.14.6: Does each input suggestion provided via a
+                            chunk of text tied by an ARIA property
+                            <code>aria-describedby</code> meet the following conditions?
+                            <ul>
+                                <li> The referenced chunk of
+                                    text has an <code>id</code> attribute</li>
+                                <li> The value of the <code>id</code>
+                                    attribute is unique</li>
+                                <li> The value of the ARIA
+                                    property <code>aria-describedby</code> matches the value of the <code>id</code>
+                                    attribute</li>
+                            </ul>
+                        </li>
+
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.3.5</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G71 - G193 - G194 - G184 -
+                            G89 - ARIA1 - ARIA6 - ARIA9 - ARIA16 - F81</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-11-15">Criterion 11.15 [AAA] For each form, is
+                        each input assistance relevant?</h3>
+                    <ul>
+                        <li id="test-11-15-1"> Test 11.15.1: For each form, is
+                            each input assistance relevant?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.3.5</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G71 - G193 - G194 - G184 -
+                            G89 - ARIA1 - ARIA9 - ARIA16 - F81</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#formulaire">Go to category: Forms</a></li>
+                <li class="bas"><a href="#consultation">Go to category: Consultation</a></li>
+            </ul>
+            <article id="navigation" class="thematique">
+                <header>
+                    <h2>Navigation</h2>
+                    <h3>General guidelines</h3>
+                    <p>Facilitate navigation in a <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
+                            of pages</a> through at least two different navigation
+                        systems (<a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
+                            menu</a>, site map or <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
+                            engine</a>), breadcrumb trail and the indication of
+                        the active page in the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation menu</a>. Identify groups
+                        of important links and the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a>, and provide the
+                        ability to avoid them through internal navigation links.
+                        Ensure that tabbing order is consistent and that the
+                        page does not contain keyboard traps.</p>
+                </header>
+                <section>
+                    <h3 id="crit-12-1">Criterion 12.1 [AA] Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
+                            of pages</a> have at least two different <a href="./RGAA3.0_Glossary_English_version_v1.html#mSysNav">navigation
+                            systems</a> (except in <a title="Particular cases for criterion 12.1"  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-1">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-12-1-1"> Test 12.1.1: Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
+                                of pages</a> meet one of the following conditions (except in <a title="Particular cases for criterion 12.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-1">particular cases</a>)?
+                            <ul>
+                                <li> A <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation menu</a> and a site map are available</li>
+                                <li> A <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
+                                        menu</a> and a <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
+                                        function</a> are available</li>
+                                <li> A <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
+                                        function</a> and a site map are available</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            2.4.5 - 2.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G63 - G64 - G161</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-2">Criterion 12.2 [AA] On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
+                            of pages</a>, are the menu or the <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation
+                            bars</a> always located at the same place (except in <a title="Particular cases for criterion 12.2"
+
+                                                                                href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-12-2-1"> Test 12.2.1: On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
+                                of pages</a>, does each page with a <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
+                                menu</a> meet the following conditions (except in <a title="Particular cases for criterion 12.2"
+
+                                                                                 href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
+                                        menu</a> is always located at the same place in
+                                    the presentation</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
+                                        menu</a> is always presented in the same relative
+                                    order in the source code.</li>
+                            </ul>
+                        </li>
+                        <li id="test-12-2-2">Test 12.2.2 Does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation
+                                bar</a> that is repeated in a set of pages meet the
+                            following conditions (except in <a title="Particular cases for criterion 12.2"
+
+                                                               href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation
+                                        bar</a> is always located at the same place in the
+                                    presentation </li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation
+                                        bar</a> is always presented in the same relative
+                                    order in the source code.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.2.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G61 - F66</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-3">Criterion 12.3 [AA] On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
+                            of pages</a>, do the menu and the <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation bars</a> have a
+                        consistent presentation (except in <a title="Particular cases for criterion 12.3"
+
+                                                              href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-12-3-1"> Test 12.3.1: On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
+                                of pages</a>, does the main <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
+                                menu</a> have a consistent presentation (except in <a title="Particular cases for criterion 12.3"
+
+                                                                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?</li>
+                        <li id="test-12-3-2"> Test 12.3.2: On each <a href="./RGAA3.0_Glossary_English_version_v1.html#mEnsemblePages">set
+                                of pages</a>, do repeated <a href="./RGAA3.0_Glossary_English_version_v1.html#mBarreNav">navigation bars</a> have a
+                            consistent presentation (except in <a title="Particular cases for criterion 12.3"
+
+                                                                  href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-">particular cases</a>)?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.2.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G61</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-4">Criterion 12.4 [AA] Is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
+                            map" page</a> relevant?</h3>
+                    <ul>
+                        <li id="test-12-4-1"> Test 12.4.1: Does the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
+                                map" page</a> represent the site general
+                            architecture?</li>
+                        <li id="test-12-4-2"> Test 12.4.2: Are the links of the
+                            site map functional?</li>
+                        <li id="test-12-4-3"> Test 12.4.3: Do the links of the
+                            site map refer to the pages that are specified by the
+                            text?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            2.4.5 - 2.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G63</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-5">Criterion 12.5 [AA] In each set of pages,
+                        is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
+                            map" page</a> accessible in an identical way?</h3>
+                    <ul>
+                        <li id="test-12-5-1"> Test 12.5.1: In each set of pages,
+                            is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
+                                map" page</a> accessible from an identical
+                            functionality?</li>
+                        <li id="test-12-5-2"> Test 12.5.2: In each set of pages,
+                            is the functionality leading to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
+                                map" page</a> located at the same place in the
+                            presentation?</li>
+                        <li id="test-12-5-3"> Test 12.5.3: In each set of pages,
+                            is the functionality leading to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mPlanSite">"site
+                                map" page</a> always presented in the same relative
+                            order in the source code?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            2.4.5 - 2.4.8 - 3.2.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G61 - G63</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-6">Criterion 12.6 [AA] In each set of pages,
+                        is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
+                            function</a> accessible in an identical way?</h3>
+                    <ul>
+                        <li id="test-12-6-1"> Test 12.6.1: In each set of pages,
+                            is the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
+                                function</a> accessible with an identical
+                            functionality?</li>
+                        <li id="test-12-6-2"> Test 12.6.2: In each set of pages,
+                            is the functionality leading to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
+                                function</a> located at the same place in the
+                            presentation?</li>
+                        <li id="test-12-6-3"> Test 12.6.3: In each set of pages,
+                            is the functionality leading to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search
+                                function</a> always presented in the same relative
+                            order in the source code?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.2.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G61 - F66</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-7">Criterion 12.7 [AA] On each page within a
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mCollecPage">collection
+                            of pages</a>, are links facilitating navigation
+                        available?</h3>
+                    <ul>
+                        <li id="test-12-7-1">Test 12.7.1: Does each page within a
+                            <a href="./RGAA3.0_Glossary_English_version_v1.html#mCollecPage">collection
+                                of pages</a>, meet the following conditions?
+                            <ul>
+                                <li>A link provides access to the next page</li>
+                                <li>A link provides access to the previous page</li>
+                                <li><a href="./RGAA3.0_Glossary_English_version_v1.html#mAccColl">Links
+                                        provide access to each page</a> of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mCollecPage">collection
+                                        of pages</a></li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            2.4.5 - 2.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G125 - G126 - G127 - G185</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-8">Criterion 12.8 [AAA] On each Web page, is a
+                        breadcrumb trail available (except in <a title="Particular cases for criterion 12.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-8">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-12-8-1">Test 12.8.1: On each web page, is a breadcrumb trail
+                            available (except in <a title="Particular cases for criterion 12.8" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-8">particular cases</a>)?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G65</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-9">Criterion 12.9 [AAA] On each Web page, is
+                        the breadcrumb trail relevant?</h3>
+                    <ul>
+                        <li id="test-12-9-1"> Test 12.9.1: On each Web page, does
+                            the breadcrumb trail represents the page position in the
+                            site structure? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G65</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-10">Criterion 12.10 [A] On each Web page,
+                        are groups of important links (menu, navigation bar&hellip;)
+                        and the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> identified (except in <a title="Particular cases for criterion 12.10" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-10">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-12-10-1">Test 12.10.1: On each Web page, is
+                            each group of important links implemented in a single tag?</li>
+                        <li id="test-12-10-2">Test 12.10.2: On each Web page, does
+                            each group of important links meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The element that structures the group of
+                                    important links has an <code>id</code> attribute</li>
+                                <li> The element that structures the group of
+                                    important links is immediately preceeded, in the
+                                    source code, with a named  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a></li>
+                                <li> the first link in the group is immediately
+                                    preceeded, in the source code, with a named  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a></li>
+                            </ul>
+                        </li>
+                        <li id="test-12-10-3"> Test 12.10.3: On each Web page,
+                            does the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> meet one of the following
+                            conditions?
+                            <ul>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> has an <code>id</code> attribute</li>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> is immediately preceeded, in the
+                                    source code, with a named  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a></li>
+                                <li> the first element of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> is
+                                    immediately preceeded, in the source code, with a
+                                    named  <a href="./RGAA3.0_Glossary_English_version_v1.html#mAncreNom">anchor</a></li>
+                            </ul>
+                        </li>
+                        <li id="test-12-10-4">Test
+                            12.10.4: On each Web page, does the <a href="./RGAA3.0_Glossary_English_version_v1.html#mDocumentOutline">document outline</a>
+                            meet the following conditions?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#PageHeader">page header</a>
+                                    has an ARIA <code>role="banner"</code></li>
+                                <li>The main <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation menu</a>
+                                    has an ARIA <code>role="navigation"</code></li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a>
+                                    has an ARIA <code>role="main"</code></li>
+                                <li>The <a href="./RGAA3.0_Glossary_English_version_v1.html#mFooter">footer</a> of the page
+                                    has an ARIA <code>role="contentinfo"</code></li>
+                                <li>The main <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation menu</a>
+                                    has an ARIA <code>role="navigation"</code></li>
+                                <li> The website <a href="./RGAA3.0_Glossary_English_version_v1.html#mMoteurRecherche">search engine</a> has an ARIA <code>role="search"</code></li>
+                                <li>The ARIA roles <code>banner</code>,
+                                    <code>main</code>, <code>contentinfo</code>, and <code>search</code> are unique in the
+                                    page</li>
+                                <li>The ARIA role <code>navigation</code>
+                                    is used only for the main and secondary <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation areas</a></li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <p><strong>Technical note:</strong> read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit12-10">technical note about the landmark roles and skiplinks</a>.
+                    </p>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.3.1 - 2.4.1 - 4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G115 - H50 - ARIA4 -
+                            ARIA11</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-11">Criterion 12.11 [A] On each Web page,
+                        are <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienEvitement">bypass
+                            or skip links</a> to groups of important links
+                        and to the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMain">main content area</a> available (except in <a title="Particular cases for criterion 12.11" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit12-11">particular cases</a>)</h3>
+                    <ul>
+                        <li id="test-12-11-1"> Test 12.11.1: On each Web page,
+                            is there a link to bypass, or skip to, each identified group of
+                            important links?</li>
+                        <li id="test-12-11-2"> Test 12.11.2: On each Web page,
+                            is there a link to bypass, or skip to, the identified content area
+                            or to access it?</li>
+                        <li id="test-12-11-3"> Test 12.11.3: On each Web page,
+                            is each <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienEvitement">bypass
+                                or skip link</a> functional?</li>
+                        <li id="test-12-11-4"> Test 12.11.4: On each set of pages,
+                            do <a href="./RGAA3.0_Glossary_English_version_v1.html#mLienEvitement">bypass
+                                or skip links</a> meet the following
+                            conditions?
+                            <ul>
+                                <li> Each link is located at the same place in the
+                                    layout</li>
+                                <li> Each link is always presented in the same
+                                    relative order in the source code</li>
+                                <li>Each link is visible at least on focus</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            2.4.1 - 2.4.3 - 3.2.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G1 - G59 - G123 - G124 -
+                            SCR28 - F66</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-12">Criterion 12.12 [AAA] On each Web page,
+                        is the current  page specified in the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
+                            menu</a>?</h3>
+                    <ul>
+                        <li id="test-12-12-1">Test 12.12.1: On each Web page, is
+                            the current  page specified in the <a href="./RGAA3.0_Glossary_English_version_v1.html#mMenuNav">navigation
+                                menu</a>?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.8</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G128</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-13">Criterion 12.13 [A] On each Web page, is
+                        <a href="./RGAA3.0_Glossary_English_version_v1.html#mOrdTab">tabbing
+                            order</a> <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">consistent</a>?</h3>
+                    <ul>
+                        <li id="test-12-13-1"> Test 12.13.1: On each Web page, is
+                            the tabbing order through the content <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">consistent</a>
+                            ?</li>
+                        <li id="test-12-13-2"> Test 12.13.2: For each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            that updates or inserts content, does tabbing order
+                            remain <a href="./RGAA3.0_Glossary_English_version_v1.html#mCoherentODL">consistent</a>?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G59 - H4 - F44 - SCR26 -
+                            SCR27 - SCR37 - C27 - F85</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-12-14">Criterion 12.14 [A] On each Web page,
+                        navigation must not contain keyboard trap. Has this rule
+                        been followed?</h3>
+                    <ul>
+                        <li id="test-12-14-1">Test 12.14.1: On each Web page, does
+                            each element that receives focus meet one of the
+                            following conditions?
+                            <ul>
+                                <li> It is possible to reach the next or previous
+                                    element that can receive focus with the tab key</li>
+                                <li> The user is informed about the existence of a functional mechanism,
+                                    allowing to reach the next or previous element that
+                                    can receive focus with the keyboard</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.1.1 - 2.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H91 - G21 - F10</p>
+                    </aside>
+                </section>
+            </article>
+            <ul class="navTheme">
+                <li class="haut"><a href="#toc">Table of contents</a></li>
+                <li class="haut"><a href="#navigation">Go to category: Navigation</a></li>
+            </ul>
+            <article id="consultation" class="thematique">
+                <header>
+                    <h2>Consultation</h2>
+                    <h3>General guidelines</h3>
+                    <p>Check that the user can control the refresh processes,
+                        sudden changes in luminosity, openings of new windows and
+                        moving or blinking content. Specify when a content opens
+                        in a new window and provide information regarding
+                        viewing of files to download. Do not make the completion
+                        of a task rely upon a time limit except if it is
+                        essential and ensure that entered data is retrieved
+                        after an authenticated session has expired. Ensure that
+                        unusual phrases and jargon are made explicit. Provide
+                        accessible versions or make downloadable documents
+                        accessible.</p>
+                </header>
+                <section>
+                    <h3 id="crit-13-1">Criterion 13.1 [A] For each Web page, can
+                        the user control each time limit that modifies content (except in <a title="Particular cases for criterion 13.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-13-1-1"> Test 13.1.1: For each Web page, does
+                            each <a href="./RGAA3.0_Glossary_English_version_v1.html#mProcedeRafraichissement">refresh
+                                process</a> or <a href="./RGAA3.0_Glossary_English_version_v1.html#mRedirectAuto">automatic
+                                redirection</a> (code, script, <code>object</code> tag, <code>applet</code> tag,
+                            <code>meta</code> tag) meet one of the following conditions (except in <a title="Particular cases for criterion 13.1"
+
+                                                                                                      href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?
+                            <ul>
+                                <li> The user can stop or restart the refresh process</li>
+                                <li> The user can increase the time limit between two
+                                    refresh processes by at least a factor of ten</li>
+                                <li> The user is warned about the imminence of the
+                                    refresh, and has at least 20 seconds to increase
+                                    the time limit before the next refresh</li>
+                                <li> The time limit between two refresh processes is at least
+                                    twenty hours</li>
+                            </ul>
+                        </li>
+                        <li id="test-13-1-2"> Test 13.1.2: For each Web page, is
+                            each redirection initiated via the <code>meta</code> tag
+                            immediate (except in <a title="Particular cases for criterion 13.1" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?</li>
+                        <li id="test-13-1-3"> Test 13.1.3: For each Web page, does
+                            each redirect process initiated via a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            meet one of the following conditions (except in <a title="Particular cases for criterion 13.1"
+
+                                                                               href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?
+                            <ul>
+                                <li> the user can stop or restart the redirect</li>
+                                <li> the user can increase the time limit to at least
+                                    ten times before redirection</li>
+                                <li> The user is warned about the imminence of the
+                                    redirection and has at least twenty seconds to
+                                    increase the time limit before the next redirection</li>
+                                <li> The time limit before the redirection is at least
+                                    twenty hours</li>
+                            </ul>
+                        </li>
+                        <li id="test-13-1-4">Test 13.1.4: For each Web page, does
+                            each server-side redirect process meet one of the
+                            following conditions (except in <a title="Particular cases for criterion 13.1"
+
+                                                               href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?
+                            <ul>
+                                <li> The user can stop or restart the redirection</li>
+                                <li> The user can increase the time limit before the
+                                    redirection to at least ten times</li>
+                                <li> The user is warned about the imminence of the
+                                    redirection and has at least twenty seconds to
+                                    increase the time limit before the next redirection</li>
+                                <li> Time limit before redirection is at least twenty
+                                    hours</li>
+                            </ul>
+                        </li>
+                        <li id="test-13-1-5">Test 13.1.5: For each Web page, does
+                            each process restricting a session time meet one of the
+                            following conditions (except in <a title="Particular cases for criterion 13.1"
+
+                                                               href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-1">particular cases</a>)?
+                            <ul>
+                                <li>The user can suppress time limit</li>
+                                <li>The user can increase time limit</li>
+                                <li>Time limit before the session expires is at least
+                                    twenty hours.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            2.2.1 - 2.2.2 - 2.2.4 - 3.2.5</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): F40 - F41 - F61 - F58 -
+                            G76 - G186 - G198 -  H76 - SVR1- SCR1 - SCR36 - G133 -
+                            G180 - G75 - G110 - SCR16</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-2">Criterion 13.2 [A] On each Web page, is
+                        the user warned each time a new window opens?</h3>
+                    <ul>
+                        <li id="test-13-2-1"> Test 13.2.1: On each Web page, for
+                            each new window opening launched via a link
+                            (target="_blank" attribute) or a JavaScript command, is
+                            the user warned?</li>
+                        <li id="test-13-2-2"> Test 13.2.2: On each Web page, for
+                            each window opening launched via an <code>object</code>, <code>applet</code> or
+                            <code>embed</code> tag, is the user warned?</li>
+                        <li id="test-13-2-3"> Test 13.2.3: On each Web page, for
+                            each window opening launched via a form control, is the
+                            user warned? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            2.4.4 - 3.2.5</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G201 - H33 - H83 - F22 -
+                            SCR24</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-3">Criterion 13.3 [A] On each Web page, the
+                        opening of a new window must not happen without user
+                        action. Has this rule been followed?</h3>
+                    <ul>
+                        <li id="test-13-3-1"> Test 13.3.1: On each Web page, the
+                            opening of a new window must not be launched without
+                            user action. Has this rule been followed? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            3.2.1 - 3.2.5</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G107 - F22 - F52 - F55 -
+                            F60</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-4">Criterion 13.4 [AAA] On each Web page, a
+                        task must not require a time limit to be completed, except
+                        if it occurs in real time or if this time limit is
+                        essential. Has this rule been followed?</h3>
+                    <ul>
+                        <li id="test-13-4-1"> Test 13.4.1: On each Web page, does
+                            each task with a time limit meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The task occurs in real time</li>
+                                <li> The task requires a time limit that is essential
+                                    for the task to occur successfully</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.2.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G5</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-5">Criterion 13.5 [AAA] On each Web page,
+                        when an authenticated session is interrupted, is the data
+                        entered by the user retrieved after re-authenticating?</h3>
+                    <ul>
+                        <li id="test-13-5-1">Test 13.5.1: On each Web page, when
+                            an authenticated session is interrupted, is the data
+                            entered by the user retrieved after re-authenticating? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.2.5</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G105 - G181 - F12</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-6">Criterion 13.6 [A] On each Web page, for
+                        each file that can be downloaded, is there sufficient
+                        information provided  (except in <a title="Particular cases for criterion 13.6"
+
+                                                            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-6">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-13-6-1"> Test 13.6.1: On each Web page, does
+                            each file that can be downloaded via a link or a form
+                            have information about its format (except in <a title="Particular cases for criterion 13.6"
+
+                                                                            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-6">particular cases</a>)?</li>
+                        <li id="test-13-6-2"> Test 13.6.2: On each Web page, does
+                            each file that can be downloaded via a link or a form
+                            have information about its weight (except in <a title="Particular cases for criterion 13.6"
+
+                                                                            href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-6">particular cases</a>)?</li>
+                        <li id="test-13-6-3"> Test 13.6.3: On each Web page, does
+                            each file that can be downloaded via a link or a form
+                            have information about its human language if necessary (except in <a title="Particular cases for criterion 13.6" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-6">particular cases</a>)? </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.4.4</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): H33</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-7">Criterion 13.7 [A] On each Web page, does
+                        each electronic <a href="./RGAA3.0_Glossary_English_version_v1.html#mVaccessible">document
+                            that can be downloaded</a> have an accessible version if
+                        necessary (except in <a title="Particular cases for criterion 13.7" href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-7">particular cases</a>)?</h3>
+                    <ul>
+                        <li id="test-13-7-1"> Test 13.7.1: On each Web page, does
+                            each downloading functionality for an electronic
+                            document meet one of the following conditions (except in <a title="Particular cases for criterion 13.7"
+
+                                                                                        href="./RGAA3.0_Particular_cases_English_version_v1.html#cpCrit13-7">particular cases</a>)?
+                            <ul>
+                                <li> The <a href="./RGAA3.0_Glossary_English_version_v1.html#mVaccessible">document
+                                        that can be downloaded</a> is
+                                    accessibility-supported</li>
+                                <li> An alternative accessibility-supported version of
+                                    the <a href="./RGAA3.0_Glossary_English_version_v1.html#mVaccessible">document
+                                        that can be downloaded</a> is available</li>
+                                <li> An alternative version of the <a href="./RGAA3.0_Glossary_English_version_v1.html#mVaccessible">documentthat
+                                        can be downloaded</a> is available in HTML format</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.1.1 - 1.3.2 - 1.3.1 - 2.4.1 - 2.4.3 - 3.1.1 - 4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G10 - G135 - F15</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-8">Criterion 13.8 [A] For each electronic
+                        document with an accessible version, does this version
+                        provide the same information?</h3>
+                    <ul>
+                        <li id="test-13-8-1">Test 13.8.1: Does each electronic
+                            document with an accessible version meet one of the
+                            following conditions?
+                            <ul>
+                                <li> The accessibility-supported version provides the
+                                    same information</li>
+                                <li> The alternative version in HTML format is
+                                    relevant and provides the same information</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.1.1 - 1.3.2 - 1.3.1 - 2.4.1 - 2.4.3 - 3.1.1 - 4.1.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G10 - G135 - F15</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-9">Criterion 13.9 [AAA] On each Web page,
+                        are unusual phrases, idioms or jargon made explicit?</h3>
+                    <ul>
+                        <li id="test-13-9-1">Test 13.9.1: On each Web page, does
+                            each phrase used in an unusual or restricted way, each
+                            idiom or jargon meet one of the following conditions?
+                            <ul>
+                                <li> A definition is available in the context right
+                                    next to the phrase and is specified by the <code>dfn</code> tag</li>
+                                <li> A definition is available via a definition list</li>
+                                <li> A definition is available in the page</li>
+                                <li>The phrase is contained in a link giving to
+                                    access to the definition.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.3</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G55 - G101 - G112 - G160 -
+                            G153 - H54</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-10">Criterion 13.10 [AAA] On each Web page,
+                        for each phrase used in an unusual or restricted way, each
+                        idiom or jargon with a definition, is this definition
+                        relevant?</h3>
+                    <ul>
+                        <li id="test-13-10-1">Test 13.10.1: On each Web page, for
+                            each phrase used in an unusual or restricted way, idiom
+                            or jargon with a definition, does this definition meet
+                            one of the following conditions?
+                            <ul>
+                                <li> The content of the associated definition is
+                                    relevant</li>
+                                <li> The content of the <code>dd</code> tag of the definition list
+                                    is relevant</li>
+                                <li> The definition provided by the adjacent context
+                                    is relevant.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            <a href="http://www.w3.org/Translations/WCAG20-fr/#meaning-idioms">3.1.3</a></p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): <a href="http://www.w3.org/TR/WCAG-TECHS/G55.html">G55</a>
+                            - <a href="http://www.w3.org/TR/WCAG-TECHS/G101.html">G101</a>
+                            - <a href="http://www.w3.org/TR/WCAG-TECHS/G112.html">G112</a>
+                            - <a href="http://www.w3.org/TR/WCAG-TECHS/H54.html">H54</a></p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-11">Criterion 13.11 [A] On each Web page,
+                        does each cryptical content (ASCII art, emoticon,
+                        cryptical syntax) have an alternative?</h3>
+                    <ul>
+                        <li id="test-13-11-1"> Test 13.11.1: On each Web page,
+                            does each cryptical content (ASCII art, emoticon,
+                            cryptical syntax) meet one of the following conditions?
+                            <ul>
+                                <li> A <code>title</code> attribute is available</li>
+                                <li> A definition is provided by the adjacent context</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            1.1.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G160 - G153 - H86 - F71 -
+                            F72</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-12">Criterion 13.12 [A] On each Web page,
+                        for each cryptical content (ASCII art, emoticon, cryptical
+                        syntax) with an alternative, is this alternative relevant?</h3>
+                    <ul>
+                        <li id="test-13-12-1"> Test 13.12.1: On each Web page,
+                            does each cryptical content (ASCII art, emoticon,
+                            cryptical syntax) meet one of the following conditions?
+                            <ul>
+                                <li> the content of the <code>title</code> attribute is relevant</li>
+                                <li> the definition provided by the adjacent context
+                                    is relevant</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            <a href="http://www.w3.org/Translations/WCAG20-fr/#text-equiv-all">1.1.1</a></p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): <a href="http://www.w3.org/TR/WCAG-TECHS/H86.html">H86</a>
+                            - <a href="http://www.w3.org/TR/WCAG-TECHS/F71.html">F71</a>
+                            - <a href="http://www.w3.org/TR/WCAG-TECHS/F72.html">F72</a></p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-13">Criterion 13.13 [AAA] On each Web page,
+                        for each word whose meaning cannot be understood without
+                        knowing the pronunciation, is this pronunciation
+                        specified?</h3>
+                    <ul>
+                        <li id="test-13-13-1">Test 13.13.1: On each Web page, does
+                            each word whose meaning cannot be understood without
+                            knowing the pronunciation, meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The phonetic pronunciation is available in the
+                                    adjacent context</li>
+                                <li> The phonetic pronunciation is accessible via a
+                                    link</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.6</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G62 - G120 - G121 - G160 -
+                            G153</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-14">Criterion 13.14 [AAA] On each Web page,
+                        does each text that requires a reading ability more
+                        advanced than the lower secondary education level have an
+                        alternative version?</h3>
+                    <ul>
+                        <li id="test-13-14-1"> Test 13.14.1: On each Web page,
+                            does each text that requires a reading ability more
+                            advanced than the lower secondary education level
+                            (except for proper names and title) meet one of the
+                            following conditions?
+                            <ul>
+                                <li> An illustration or graphic symbols adapted to the
+                                    reading level of the lower secondary education level
+                                    are available</li>
+                                <li> A version in sign language (adapted to the human
+                                    language of the content) is available</li>
+                                <li> A spoken version of the text is available</li>
+                                <li> A summary adapted to the reading level of the
+                                    lower secondary education level is available.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            3.1.5</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G79 - G86 - G103 - G160 -
+                            G153</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-15">Criterion 13.15 [A] On each Web page,
+                        are <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangeLumi">sudden
+                            changes in luminosity or flashing effects</a> used
+                        accurately?</h3>
+                    <ul>
+                        <li id="test-13-15-1">Test 13.15.1: On each Web page, does
+                            each animated image (<code>img</code> tag, <code>svg</code> tag, or <code>object</code> tag)
+                            causing a suddent change in luminosity or a flashing
+                            effect meet one of the following conditions?
+                            <ul>
+                                <li> The effect's frequency is lower than 3 per
+                                    second</li>
+                                <li> The cumulated area of effects is smaller than
+                                    or equal to 21,824 pixels</li>
+                            </ul>
+                        </li>
+                        <li id="test-13-15-2"> Test 13.15.2: On each Web page,
+                            does each <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            causing a sudden change in luminosity or a flashing
+                            effect meet one of the following conditions?
+                            <ul>
+                                <li> The effect's frequency is lower than 3 per second</li>
+                                <li> The cumulated area of the effects is less
+                                    than or equal to 21,824 pixels</li>
+                            </ul>
+                        </li>
+                        <li id="test-13-15-3"> Test 13.15.3: On each Web page,
+                            does each CSS layout causing a sudden change in
+                            luminosity or a flashing effect meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The effect's frequency is lower than 3 per second</li>
+                                <li>The cumulated area of the effects is less
+                                    than or equal to 21,824 pixels</li>
+                            </ul>
+                        </li>
+                        <li id="test-13-15-4"> Test 13.15.4: On each Web page,
+                            does each Java applet causing a sudden change in
+                            luminosity or a flashing effect meet one of the following
+                            conditions?
+                            <ul>
+                                <li> The effect's frequency is lower than 3 per second</li>
+                                <li> The cumulated area of the effects is less
+                                    than or equal to 21,824 pixels</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.3.1</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G15 - G19 - G176</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-16">Criterion 13.16 [AAA] On each Web page,
+                        do the <a href="./RGAA3.0_Glossary_English_version_v1.html#mChangeLumi">sudden
+                            changes in luminosity or flashing effects</a> have a
+                        frequency lower than or equal to 3 per second?</h3>
+                    <ul>
+                        <li id="test-13-16-1">Test 13.16.1: On each Web page, does
+                            each sudden change in luminosity or a flashing effect
+                            caused by an animated image (<code>img</code> tag, <code>svg</code>
+                            tag, <code>embed</code> tag, <code>canvas</code> tag, or <code>object</code> tag) have
+                            a frequency lower than or equal to 3 per second?</li>
+                        <li id="test-13-16-2"> Test 13.16.2: On each Web page,
+                            does each sudden change in luminosity or a flashing
+                            effect caused by a <a href="./RGAA3.0_Glossary_English_version_v1.html#mScript">script</a>
+                            have a frequency lower than or equal to 3 per second?</li>
+                        <li id="test-13-16-3"> Test 13.16.3: On each Web page,
+                            does each sudden change in luminosity or a flashing
+                            effect caused by CSS layout have a frequency lower than
+                            or equal to 3 per second?</li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criterion:
+                            2.3.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G19</p>
+                    </aside>
+                </section>
+                <section>
+                    <h3 id="crit-13-17">Criterion 13.17 [A] On each Web page,
+                        can each moving or blinking content be <a href="./RGAA3.0_Glossary_English_version_v1.html#mControleMov">controlled
+                            by the user</a>?</h3>
+                    <ul>
+                        <li id="test-13-17-1">Test 13.17.1: On each Web page, does
+                            each moving content that starts moving automatically, meet one
+                            of the following conditions?
+                            <ul>
+                                <li> The motion stops within 5 seconds</li>
+                                <li> The user can stop and restart the motion</li>
+                                <li> The user can display or hide the moving content</li>
+                                <li> The user can display the same information without moving content.</li>
+                            </ul>
+                        </li>
+                        <li id="test-13-17-2"> Test 13.17.2: On each Web page,
+                            does each blinking content that starts blinking automatically,
+                            meet one of the following conditions?
+                            <ul>
+                                <li> The blinking stops within 5 seconds</li>
+                                <li> The user can stop and restart the blinking</li>
+                                <li> The user can display and hide the blinking content</li>
+                                <li> The user can display the whole information without blinking content.</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <aside>
+                        <h4>Mapping with WCAG 2.0  </h4>
+
+                        <p>WCAG 2.0 success criteria:
+                            1.2.4 - 1.2.9 - 2.2.1 - 2.2.2</p>
+                        <p>WCAG 2.0 sufficient technique(s)
+                            and/or failure(s): G4 - G11 - G152 - G186 -
+                            G187 - G191 - SM11 - SM12 - F47 - F50 - F4 - F7 - F16 -
+                            SCR22 - SCR33 - SCR36</p>
+                    </aside>
+                </section>
+            </article>
+        </main>
+    </body>
 </html>

--- a/RGAA3.0_Glossary_English_version_v1.html
+++ b/RGAA3.0_Glossary_English_version_v1.html
@@ -14,7 +14,7 @@
             <nav id="nav" role="navigation">
                 <ul>
                     <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
-                    <li><a>Glossary</a></li>
+                    <li>Glossary</li>
                     <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
                     <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
                     <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
@@ -1287,7 +1287,7 @@
             </h3>
 
             <p>
-                <a href="#mTabDonnee"></a>Data tables are considered as complex, in the RGAA, when they have header cells outside of the first row and/or column, or whose scope does not cover the whole row or column. For these tables it is necessary to provide a summary, to describe their nature and structure, in order to ease its consultation by assistive technologies users, in particular.
+                <a href="#mTabDonnee">Data tables</a> are considered as complex, in the RGAA, when they have header cells outside of the first row and/or column, or whose scope does not cover the whole row or column. For these tables it is necessary to provide a summary, to describe their nature and structure, in order to ease its consultation by assistive technologies users, in particular.
             </p>
 
             <h3 id="mTabDonnee">

--- a/RGAA3.0_Glossary_English_version_v1.html
+++ b/RGAA3.0_Glossary_English_version_v1.html
@@ -1,1452 +1,1448 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta http-equiv="content-type" content="charset=UTF-8" />
-
-    <title>RGAA 3.0 Glossary - English translation</title>
-    <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Glossary." name="description" />
-    <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, glossary" name="keywords" />
-
- </head>
-  <body>
-     <header role="banner">
-      <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
-      <nav id="nav" role="navigation">
-        <ul>
-          <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
-          <li><a>Glossary</a></li>
-          <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
-          <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
-          <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
-          <li><a href="./RGAA3.0_References_English_version_v1.html">References</a></li>
-        </ul>
-      </nav>
-      <h1>
-        <abbr lang="fr" title="Référentiel Général d'Accessibilité des Administrations">RGAA</abbr> 3.0 - Glossary - English translation
-      </h1>
-      <p>The RGAA is the French government's General Accessibility Reference for Administrations. It is meant to provide a way to check compliance against <abbr title="Web Content Accessibility Guidelines, version 2.0">WCAG 2.0</abbr>.</p>
-      <p>
-        This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
-      </p>
-      <p>
-        The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
-      <p>
-        Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
-      </p>
-      <p>
-        Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
-      </p>
-        <h2 id="toc">
-          Table of Contents
-        </h2>
-        <nav role="navigation" aria-labelledby="toc">
-          <ul>
-            <li><a href="#a">A</a></li>
-            <li><a href="#b">B</a></li>
-            <li><a href="#c">C</a></li>
-            <li><a href="#d">D</a></li>
-            <li><a href="#e">E</a></li>
-            <li><a href="#f">F</a></li>
-            <li><a href="#h">H</a></li>
-            <li><a href="#i">I</a></li>
-            <li><a href="#l">L</a></li>
-            <li><a href="#m">M</a></li>
-            <li><a href="#n">N</a></li>
-            <li><a href="#o">O</a></li>
-            <li><a href="#p">P</a></li>
-            <li><a href="#r">R</a></li>
-            <li><a href="#s">S</a></li>
-            <li><a href="#t">T</a></li>
-            <li><a href="#u">U</a></li>
-            <li><a href="#v">V</a></li>
-            <li><a href="#w">W</a></li>
-          </ul>
-        </nav>
-    </header>
-<main role="main">
-
-<p class="navTheme"><a href="#b">Skip to B</a></p>
-<h2 id="a">A</h2>
-<h3 id="mAccColl">Access to each page (of the collection of pages)</h3>
-  <p>
-    In the cases where the collection contains a large number of pages, it is usual to provide only links to one page in ten, for instance. This practice passes the test.
- </p>
-<h3 id="mAAClavierSouris">Accessible and activable by keyboard and mouse</h3>
-<ul>
-<li> A user interface component (link, button, clickable element in a Flash movie&hellip;) is accessible by keyboard and mouse when it can receive  focus, indifferently, through the use of the mouse pointer or the Tab key.
-</li>
-<li>A user interface component (link, button, clickable element in Flash&hellip;) can be activated with keyboard and mouse when the user can initiate the action triggered by the user interface component indifferently with a mouse click or the Enter key.</li>
-<li>
-<strong>Warning</strong>: for some user interface components such as sliders (sliding or rotating button&hellip;), it is not possible to control the component only with the Enter key. In this situation, other keys (such as the arrow keys) can be used.
-</li>
-</ul>
-<p>
-<strong>Important notice:</strong> Some technologies can make focus management too complex or unstable to rely only upon the Tab, arrow and Enter keys.
-</p>
-<p>In this case, keyboard shortcuts may be the only solution to make the composant usable.</p>
-<p>The criterion can be considered as Compliant, if the keyboard shortcuts are appropriately documented, and operable for every location of the focus in the user interface.</p>
-<p>The following WCAG Technique:  <a href="http://www.w3.org/WAI/GL/WCAG20-TECHS/SL15.html">SL15: Providing Keyboard Shortcuts that Work Across the Entire Silverlight Application</a> provides information on this matter, for the Silverlight technology. </p>
-
-<h3 id="mVaccessible">Accessible version (of a downloadable document)</h3>
-
-<p>Downloadable documents provided in format types that are accessibility-supported must be accessible, or an alternate accessible version, or an accessible HTML version, must be provided. The document formats considered as  accessibility-supported are:</p>
-<ul>
-	<li>Microsoft Office (Word 2003 and later, OOXML)</li>
-	<li>   Open Office Org (ODF)</li>
-	<li>    Adobe PDF</li>
-	<li>    Epub/Daisy</li>
-</ul>
-<p>Contents must conform to the <a href="http://references.modernisation.gouv.fr/sites/default/files/liste-criteres-documents-bureautiques-telechargement-RGAA.odt">list of criteria for downloadable electronic documents (ODT, 56 kb, in French)</a>.</p>
-<p>
-<strong>Note:</strong>The txt format cannot be used to provide an accessible version of a downloadable document.
-</p>
-<h3 id="mAdaptsARIADP">Adapts a design pattern defined by the ARIA API</h3>
-<p>The ARIA API defines design patterns, for tab lists or modal windows for example, designed to provide a standardized behavior for user interface components. The application of these design patterns is required by the RGAA.</p>
-<p>However, it is possible to adapt these design patterns, by replacing a poorly supported property by an equivalent one, or by enriching the component with properties that improve the user experience, or secure the component's behaviour.</p>
-<p>It is the author's responsibility to check that these adaptations are consistent with the design pattern; that they do not modify the expected behavior, from a user experience point of view; and that the adapted component is correctly rendered by assistive technologies.</p>
-<p>If these requirements are met, the component can be declared "compliant" with the design pattern.</p>
-<h3 id="mLienAdj">Adjacent link</h3>
-<p>Link adjacent to an element both in the layout (CSS enabled) and in the HTML code. In the HTML code, the link must be just before or after the element it is adjacent to.</p>
-<h3 id="mAlerte">Alert</h3>
-<p>Alert message that interrupts navigation or consultation, requiring the user to click on a button or a link in order to proceed; for example, a dialog box generated via the <code>alert</code> JavaScript function. By extension, a pop-in (content presented in an overlay, is inserted in the DOM) that needs to be closed to proceed, is considered as an alert.</p>
-<p>
-	<strong>Note:</strong> An option may be proposed  to disable the alerts before they are triggered, for example, via a user parameter. Other example:  when the first alert is displayed, a checkbox "do not display this alert anymore" can be ticked by the user. </p>
-
-<h3 id="mMecaRempl">Alternate mechanism</h3>
-<p>
-Mechanism (CSS-based, generally), allowing the user to replace text with an image of text, and reversely, like a style switcher for instance. The mechanism can rely either on a server-side or client-side script language.
-</p>
-<h3 id="mAltCC">Alternative (short and concise)</h3>
-<p>
-Rendering a text alternative via an assistive technology (like a screen magnifier for instance), requires that it should be as short as possible. A length of 80 characters is strongly recommended; it will reduce the manipulations to read the text alternative for users of Braille displays or screen magnifiers, in particular.
-</p>
-<h3 id="mAltTexteImg">Alternative (Text alternative of an image)</h3>
-<p>
-A text asssociated to an image via an appropriate technique, describing the information conveyed by the image (in relation with the context of the Web content it is included in). RGAA considers four types of alternatives, depending on the purpose of the image:</p>
-<ul>
-	<li>
-    <strong>For an image that conveys information</strong>, the text alternative provides the information needed to understand the content the image is associated with;
-</li>
-<li>
-    <strong>For a decorative image</strong>, the alternative must be empty (<code>alt=""</code>);
-</li>
-<li>
-    <strong>For an image link</strong>, the text alternative describes the purpose or the target of the link;
-</li>
-<li>
-    <strong>For a CAPTCHA or test image</strong>, the text alternative can not provide the information conveyed by the image without compromising  the associated security function. In this case, the alternative should only describe the nature and purpose of the image.
-</li>
-</ul>
-<p><strong>Note 1:</strong> for a CAPTCHA image, the text alternative can be, for instance: "anti-spam security code", or "code to check you are human", or any other text providing the user with the ability to understand the nature and purpose of the image.
-</p>
-<p>
-<strong>Note 2:</strong>Groups of non-linked images may constitute a particular case, when they provide an information as a group rather than as a single image. For example: several images of a star graphically describe the average result in an online voting system. In such cases, it is strongly recommended to provide a text alternative for the first image, that describes the purpose of the group, while the other images will be considered as decorative. On this subject, you may read this technical note: <a href="http://www.w3.org/TR/html-alt-techniques/#a-group-of-images-that-form-a-single-larger-picture-with-no-links-1">1.10 A group of images that form a single larger picture with no links</a>.
-</p>
-<h3 id="mAltScript">Alternative (to a script)</h3>
-<p>
-Text or process associated with the script, via an appropriate technique, and providing a function or a content similar to the one provided by the script.</p>
-<p><strong>Note:</strong>
-when an alternative to a JavaScript functionality is available, the website must provide the way to access it. It can be a link or a button providing access to an alternative page not relying upon JavaScript, or allowing to replace the component by an alternative component that does not rely on JavaScript, for instance.
-	</p>
-
-<h3 id="mAudioOnly">
-Alternative audio-only version
-</h3>
-<p>An audio-only version is an audio-based version of a content (in a form of a downloadable MP3 file for instance), provided as an alternative to video-only (video document with no audio information). The only impacted users, with video-only content, being users with visual impairments, WCAG considers as acceptable to provide an audio-only version.</p>
-<p>The audio-only version must include all the useful visual information found in the video.</p>
-<p>It is generally simpler to produce an audio version than a textual one when the video is very descriptive (the transcription requiring then a heavy workload in terms of copywriting). Authors are reminded, though, that only text transcripts provide a universal access to the information provided by the video. Indeed, video incurs potentially other barriers, like for users who do not have to ability to play the audio or video content.</p>
-
-<h3 id="mAmbigueTtMonde">Ambiguous for everybody</h3>
-
-<p>
-    the purpose cannot be determined from the link and all information of the Web page presented to the user simultaneously with the link (i.e., readers without disabilities would not know what a link would do until they activated it)
-</p>
-<p>
-    Example: The word guava in the following sentence "One of the notable exports is guava" is a link. The link could lead to a definition of guava, a chart listing the quantity of guava exported or a photograph of people harvesting guava. Until the link is activated, all readers are unsure and the person with a disability is not at any disadvantage.
-</p>
-<h3 id="mAncreNom">Anchor</h3>
-
-<p>
-In HTML, an anchor (also called bookmark) is composed of an <code>&lt;a&gt;</code>  tag with the <code>id</code> attribute and with no <code>href</code>; for example: <code>&lt;a id="content"&gt;&lt;/a&gt;</code>.
-An anchor serves as a target for a link like  <code>&lt;a href="index.html#content"&gt;skip to content&lt;/a&gt;</code>.
-</p>
-<h3 id="mZone">Area (of an image map)</h3>
-<p>Clickable or non clickable area of an image map.</p>
-<h3 id="mZoneCliquable">Area (Clickable)</h3>
-<p>
-Image map with an attached behavior; for example, triggering an event by clicking on a link (for a client-side clickable area: <code>area</code> tag with a <code>href</code> attribute). The <code>area</code> tags are descendants of a <code>map</code> tag.
-</p>
-<p>With server-side image maps, the coordinates are stored on the server.</p>
-<h3 id="mZoneNonCliquable">Area (Non clickable)</h3>
-<p>
-Image map with no attached behavior (for a client-side area: <code>area</code> tag with no <code>href</code> attribute). The <code>area</code> tags are descendants of a <code>map</code> tag.
-</p>
-<h3 id="mZoneTexte">Area (Text)</h3>
-<p>
-Image map region containing text.
-</p>
-
-
-<h3 id="mAudioDescE">Audio description (Extended)</h3>
-<p>Audio description that is added to an audiovisual presentation by pausing the video so that there is time to add additional description.</p>
-
-    <p>
-    	<strong>Note:</strong> This technique is only used when the sense of the video would be lost without the additional audio description and the pauses between dialogue/narration are too short.
-    </p>
-
-
-<h3 id="mAudioDesc">Audio description (Synchronized, time-based media)</h3>
-<p>
-    Narration added to the soundtrack to describe important visual details that cannot be understood from the main soundtrack alone. The audio description must be synchronized with the time-based media</p>
-
-<p>
-    <strong>Note 1:</strong> Audio description of video provides information about actions, characters, scene changes, on-screen text, and other visual content.
-</p>
-<p>
-    <strong>Note 2:</strong> In standard audio description, narration is added during existing pauses in dialogue. (See also extended audio description.)
-<p><strong>Note 3:</strong> Where all of the video information is already provided in existing audio, no additional audio description is necessary.</p>
-
-<h3 id="mRedirectAuto">Automatic redirection</h3>
-<p>
-    Process consisting in automatically redirecting the user from a page to another, on the same domain or a different domain.</p>
-
-
-<ul class="navTheme">
-	<li><a href="#a">Skip to A</a></li>
-	<li><a href="#c">Skip to C</a></li>
-</ul>
-<h2 id="b">B</h2>
-<h3 id="mBtnForm">Button (form)</h3>
-<p>A form element designed to perform a predefined action when activated. For instance, a submit button, when pressed, initiates the transmission of the data collected from the form to the web server. The button text must describe the action resulting in its activation (for example: "Start search", "Send your message").
-</p>
-<p>
-In HTML, there are three types of button elements:</p>
-<ul>
-	<li><code>INPUT</code> of type <code>submit</code>, <code>reset</code> or <code>button</code>,</li>
-    <li><code>INPUT</code> of type <code>image</code>,</li>
-    <li><code>BUTTON</code>.</li>
-</ul>
-<p>
-There can be four types of button text:</p>
-<ul>
-    <li>the content of the <code>value</code> attribute, for buttons of type <code>submit</code>, <code>reset</code> or <code>button</code>,</li>
-    <li>the content of the <code>alt</code> attribute for a button of type <code>image</code>,</li>
-    <li>the content of the <code>title</code> attribute when it is defined,</li>
-    <li>the content of the <code>button</code> tag.</li>
-</ul>
-
-<h3 id="mLienEvitement">
-Bypass or skip links
-</h3>
-
-<p>Links whose purpose is to navigate inside of content (skip link, link to  the search form or the menu).</p>
-
-<ul class="navTheme">
-	<li><a href="#b">Skip to B</a></li>
-	<li><a href="#d">Skip to D</a></li>
-</ul>
-<h2 id="c">C</h2>
-<h3 id="mcaptcha">
-CAPTCHA
-</h3>
-<p>
-A CAPTCHA is a test designed to tell computers and humans apart. The test is often based on images containing distorted text, mixed with other shapes, or with altered colors. The user is requested to key in the obscured characters. Other forms of CAPTCHA can be based on logical questions or audio clips.
-</p>
-<h3 id="mChangContexte">
-Change of context
-</h3>
-
-<p>Major changes in the content of the Web page that, if made without user awareness, can disorient users who are not able to view the entire page simultaneously. Changes in context include changes of:</p>
-
-<ol>
-    <li>user agent</li>
-    <li>viewport</li>
-    <li>focus</li>
-    <li>content that changes the meaning of the Web page</li>
-</ol>
-
-<p><strong>Note:</strong> A change of content is not always a change of context. Changes in content, such as an expanding outline, dynamic menu, or a tab control do not necessarily change the context, unless they also change one of the elements listed above (e.g., focus).</p>
-
-<p><strong>Example:</strong> Opening a new window, moving focus to a different component, going to a new page (including anything that would seem to to users as if they had moved to a new page) or significantly re-arranging the content of a page, are examples of changes of context.</p>
-
-<h3 id="mChangeNativeRole">
-Change of native role of an HTML element
-</h3>
-<p>The WAI-ARIA specification allows to modify the native role of an element, like for instance changing an <code>A</code> element (with an href attribute) into a <code>BUTTON</code> element.
-</p>
-<p>These modifications can be made only under certain conditions, described in the document <a href="https://www.w3.org/TR/aria-in-html/">Notes on Using WAI-ARIA in HTML</a>, which defines several restrictions, in particular.
-</p>
-<p>To be considered conformant, a change of the native role of an HTML element via WAI-ARIA must comply with these restrictions.
-</p>
-
-<h3 id="mChangeLumi">
-Changes in luminosity (sudden) or flashing effects
-</h3>
-<p>A rapid alternance of colors with very different levels of luminosity, that can cause seizures in some people, if the flashing area is large enough, and the rate of change within specific frequency ranges.
-</p>
-
-
-
-<h3 id="mTailleCaractere">
-Character size
-</h3>
-Size of the characters of textual content found in the page. In order to be accessible, font sizes must be defined with relative units (<code>%</code>, <code>em</code> or <code>rem</code>) or keywords (<code>xx-small</code>, <code>x-small</code>, <code>small</code>, <code>medium</code>, <code>large</code>, <code>x-large</code>, <code>xx-large</code>, <code>smaller</code>, or <code>larger</code>).
-<p><code>Note:</code> with regards to the RGAA, the use of the pixel unit (<code>px</code>) is prohibitted.</p>
-
-<h3 id="mCollecPage">
-Collection of pages
-</h3>
-<p>
-Pages linked to each other via hyperlinks, and with a common subject or nature. For example, the result pages of a search engine or the pages of a catalogue are collections of pages.</p>
-
-<h3 id="mCoherentODL">
-Consistent (reading or tabbing order)
-</h3>
-
-<p>Consistent content is readable (the elements order is logical) and understandable (the reading logic is consistent).
-</p>
-
-
-<h3 id="mContraste">
-Contrast (color)
-</h3>
-
-<p>Significant opposition between a foreground color and a background color. The contrast ratio is based on the difference of relative luminance between background and foreground according to the rule: (L1 + 0.05) / (L2 +0.05) where L1 is the relative luminance of the lighter color, and L2 is the relative luminance of the darker  color. The luminance is calculated according to the following formula: L = 0,2126 * R + 0,7152 * G + 0,0722 * B where R, G and B are defined as:
-<ul>
-		<li>if RsRGB >= 0,03928 then R = RsRGB/12,92 else R = ((RsRGB+0,055)/1,055) ^ 2,4</li>
-	<li> if GsRGB >= 0,03928 then --G = GsRGB/12,92 else G = ((GsRGB+0,055)/1,055) ^ 2,4</li>
-	 <li>if BsRGB >= 0,03928 then B = BsRGB/12.92 else B = ((BsRGB+0,055)/1,055) ^ 2,4</li>
-</ul>
-<p> and RsRGB, GsRGB, and BsRGB are defined as:</p>
-
- <ul>
- 	<li>RsRGB = R8bit/255</li><li> GsRGB = G8bit/255</li><li> BsRGB = B8bit/255</li>
- </ul>
-
-
-<p> The "^" character is the exponentiation operator.</p>
-
-<p><strong>Note:</strong> The contrast measurment is related to the text, the image of text, text and images of text in animations, the text in captions, and text that is embedded in videos. As far as text and images of text of animations and the text in captions and embedded text in videos are concerned, the font size must be measured according to the default displaying size, (as displayed). Text that is avaailable in the elements of an image or a video (for example a sign, a poster etc.) are not concerned.</p>
-
-
-<h3 id="mControlSound">
-Control (of autoplaying sound)
-</h3>
-
-<p>Ability for the user to pause and play an autoplaying sound.
-</p>
-<p><strong>Note:</strong> when appropriate, the controlling device should be the first element in the page.</p>
-
-<h3 id="mFonctionControle">
-Control features (time-based media)
-</h3>
-<p>Functionalities enabling the user to control the playing of a time-based media, with the keyboard or the mouse, at least. The following requirements must be met:
-</p>
-<ul>
-<li>List of required control features:
-  <ul>
-      <li>the time-based media must always have at least the following features: play, pause, stop ;
-    </li>
-    <li>if the time-based media has sound, it must have a feature to set the sound on and off, and to control the volume;
-    </li>
-    <li>if the time-based media has captions, it must have a feature enabling to display and hide  captions;
-    </li>
-    <li>if the time-based media has an audio description, it must have a feature enabling to activate and disactivate the  audio description.
-  </li>
-  </ul>
-</li>
-<li>Each functionality mus be accessible with the keyboard, via the Tab key, and the mouse, at least;</li>
-<li>Each functionality must be actionable with the keyboard or the mouse, at least.</li>
-</ul>
-
-<p><strong>Note:</strong> If a multimedia object has no sound, there is no need for a feature to control its volume.
-</p>
-
-
-<h3 id="mControleMov">
-Control (moving or blinking content)
-</h3>
-
-<p>Ability for the user to control the display or reading of moving or blinking content at least with the keyboard and the mouse.
-</p>
-<p>Every content in motion, except time-based media ruled by the "Multimedia" criteria category, are concerned: animated images (like animated GIFs), content in motion served via an <code>object</code> tag, JavaScript code, or CSS effects, for example.
-</p>
-<p><strong>Note 1:</strong> when appropriate, the controlling device should be the first element in the page.</p>
-<p><strong>Note 2:</strong> the controlling device must not prevent the user from interacting with the rest of the page. Consequently, stopping or pausing a content in motion via an event triggered on focus, fails this criterion.</p>
-<p><strong>Note 3:</strong> in some cases, the motion is part of the component, and it can not be controlled by the user. Example: a progress bar indicating by its movement the progress of an event like a download. In this case, the criterion is not applicable.</p>
-
-<h3 id="mControleClavSour">
-Controllable by keyboard and mouse
-</h3>
-
-<p>Controlling a functionality with the keyboard means that it can be accessed via the Tab key and activated via the Enter key, except for:
-</p>
-<ul>
-<li>User interface components implementing WAI-ARIA, when a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDesignPAttern">Design Pattern</a> defines requirements for specific  keyboard interactions;
-</li>
-<li>When a component makes use of a technology that requires keyboard shortcuts, and the Tab key is not available.</li>
-</ul>
-
-<h3 id="mEnvMait">
-Controlled environment
-</h3>
-
-<p>Any environment in which access to information, technologies, terms of use and users profiles can be known and controlled. The main elements for which control is essential are:
-</p>
-<ul>
-	    <li>The browsers types and versions
-    </li>
-    <li>The supported technologies, their versions and activation statuses (JavaScript, WAI-ARIA, Flash&hellip;)
-    </li>
-    <li>The assistive technologies and any device used in a specific way by users with disabilities
-    </li>
-    <li>The operating systems and accessibility APIs
-    </li>
-    <li>The level of proficiency of users of assistive technologies, for any specific device (user interface, online application&hellip;) in use in this environment.
-</li>
-
-</ul>
-<p>Authors and administrators must guarantee that the technologies in use, and the way they are utilized by users, are compatible with their technologies (including assistive technologies). Information services or Web sites, whatever their status, that provide public access cannot be considered as controlled environments.</p>
-
-<h3 id="mCorrectlyRendered">
-Correctly rendered (by assistive technologies)
-</h3>
-When a criterion, a test or a test condition requires to verify that a device is correctly rendered by assistive technologies, it must be checked that this rendering is accessibility supported.
-The test consists in checking that the rendering is relevant for at least one combination of the <a href="./RGAA3.0_Baseline_English_version_v1.html">Reference baseline</a> used to declare that an element, a device or an alternative is "accessibility supported".
-For example: Test 1.3.7 requires to check that the alternative of a vector image conveying information is correctly rendered.
-The rendering is then tested with NVDA (last version) and Firefox, JAWS (previous version) and Internet Explorer 9+, and VoiceOver (last version) and Safari.
-If the alternative is correctly rendered, then the test is passed.
-
-
-<h3 id="mPropCouleur">
-CSS property defining a color
-</h3>
-
-<p>This concerns the following CSS properties: <code>color</code>, <code>background>-color</code, <code>background</code>, <code>border-color</code>, <code>border</code>, <code>outline-color</code>, <code>outline</code>.
-</p>
-<p> <strong>Note:</strong> the use of a background image to set a color (<code>bakground:url(&hellip;)</code> property) is also concerned.
-</p>
-
-<ul class="navTheme">
-	<li><a href="#c">Skip to C</a></li>
-	<li><a href="#e">Skip to E</a></li>
-</ul>
-
-<h2 id="d">D</h2>
-
-<h3 id="mTypeDonnes">
-Data type and format
-</h3>
-
-<p>Indication regarding expected data type and format when information is entered in a form field. For example:
-</p>
-    <ul>
-      <li>date (yyyy/mm/dd)</li>
-    <li>Total in euros</li>
-    <li>Zip code (5 numbers: eg. 75001)</li>
-
-    </ul>
-<p><strong>Important note</strong>: when the type of the form field involves an input mask, like for instance fields of types <code>date</code> or <code>time</code>, the indication of expected format is not required.</p>
-
-
-<h3 id="mLangueDefaut">
-Default human language
-</h3>
-
-<p>Language specification used by the user-agent (including assistive tchnologies) to apply language-specific  rules when rendering content. The language code is provided via the <code>lang</code> and/or <code>xml:lang</code> attributes, defined for the <code>html</code> tag (container for the whole document in the web page), or every descendant tag with content to which these rules should apply. The choice of attributes depends on the Document Type Definition (DTD) used:
-</p>
-<ul>
-  <li>For HTML up to version 4.01:  <code>lang</code> attribute mandatory, <code>xml:lang</code> attribute not supported;
-    </li>
-    <li>For XHTML 1.0 served in "text/html": <code>lang</code> and <code>xml:lang</code> attributes mandatory;
-    </li>
-    <li>For XHTML 1.0 served in "application/xhtml+xml": <code>xml:lang</code> attribute mandatory, <code>lang</code> attribute recommended;
-    </li>
-    <li>For XHTML 1.1: <code>xml:lang</code> attribute mandatory, <code>lang</code> attribute not supported;</li>
-    <li>For HTML5: <code>lang</code> attribute mandatory.</li>
-
-</ul>
-
-
-<h3 id="#mDesignPattern">
-Design Pattern
-</h3>
-<p>A design pattern is a model defined by the ARIA API describing the structure, roles, properties and behaviors a JavaScript component (widget) must have.</p>
-<p>The design patterns are described in this document: <a href="http://www.w3.org/WAI/PF/aria-practices/">WAI-ARIA 1.0 Authoring PRactices</a>.
-</p>
-<p>A JavaScript-based component must follow the design pattern corresponding with its WAI-ARIA role.
-</p>
-
-<p><strong>Note 1</strong>: because some WAI-ARIA properties and roles are not supported by all user agents, and because of the wide variety of situations where a JavaScript component can be used, it is allowed to adapt design patterns to specific contexts or uses. In this case, the adapted design pattern must:
-</p>
-<ul>
-
-<li>respect the general structure; for instance, a tab panel is necessarily associated with a tab list;
-</li>
-<li>in place of a WAI-ARIA role or property with poor support, equivalent WAI-ARIA roles or properties may be used as long as they display similar behavior and rendering by user agents
-</li>
-</ul>
-<p><strong>Note 2:</strong> this does not apply to enrichments of a design pattern with WAI-ARIA roles or properties, for which accessibility support is verified through rendering tests with the reference baseline. For example, adding the <code>aria-hidden</code> property on tab panels (<code>role="tabpanel"</code>) is not considered as an adapted design pattern.
-</p>
-
-<h3 id="mDescDetaillee">
-Detailed description (image)
-</h3>
-
-<p>Content related to an image in addition to its text alternative, in order to fully describe information conveyed by the image. The detailed description can be inserted via:</p>
-
-<ul>
-	    <li>a <code>longdesc</code> attribute containing the URL of a page, or of a content in the same page, containing the detailed description,
-    </li>
-    <li>a reference, in the <code>alt</code> attribute, to a detailed description adjacent to the image,
-    </li>
-    <li>A link adjacent to the image, to a page or a content in the same page, containing the detailed description,
-</li>
-<li>A chunk of text, associated to the image by means of aria-labelledby or aria-describedby properties.</li>
-
-</ul>
-
-
-<h3 id="mDocumentOutline">Document outline</h3>
-<p>
-The Test 9.2.2 requires that the structure of the sectioning elements (<code>NAV</code>), <code>SECTION</code>, <code>ARTICLE</code> for instance) in the page is coherent; meaning it's representative of the document's architecture. This structure is completed by the headings (<code>h1</code> to <code>h6</code> tags) structure, which is also a part of it.
-</p>
-<p>Inappropriate use of these sectioning elements could result in an incoherent document outline, through excessive use of <code>SECTION</code> or <code>ARTICLE</code> elements for example.</p>
-<p><strong>Note 1:</strong>The document outline algorithm is progressively supported by browsers and assistive technologies. Considering that, in any case, the RGAA requires a robust and coherent headings hierarchy, <strong>it is acceptable to consider the Test 9.2.2 as not applicable</strong> when a perfectly coherent document outline can not be guaranteed. You may read this technical note: <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-2">Technical note on document outline</a>.</p>
-<p><strong>Note 2</strong>You may read, on the same subject, the example provided in the HTML5 specification: <a href="http://www.w3.org/TR/html5/sections.html#sample-outlines">4.3.10.2 Sample outlines</a>.
-</p>
-
-<h3 id="mDTD">
-Document type
-</h3>
-
-<p>Set of reference data allowing user agents to know the technical characteristics of the languages used in the page (<code>doctype</code> tag).
-</p>
-
-<ul class="navTheme">
-	<li><a href="#d">Skip to D</a></li>
-	<li><a href="#f">Skip to F</a></li>
-</ul>
-<h2 id="e">E</h2>
-<!--
-<h3 id="mEquivalentRole">
-Equivalent WAI-ARIA role
-</h3>
--->
-
-<h3 id="mExpliciteHorsContexte">
-Explicit out of context (link)
-</h3>
-
-<p>A link is explicit out of its context when the link text (content between <code>&lt;a href=""&gt;</code> and <code>&lt;/a&gt;</code>) provides enough information to understand the function and purpose of the link.</p>
-
-<ul class="navTheme">
-	<li><a href="#e">Skip to E</a></li>
-	<li><a href="#g">Skip to G</a></li>
-</ul>
-<h2 id="f">F</h2>
-
-<h3 id="mPriseFocus">
-Focus
-</h3>
-
-<p>Focus is the state sent by an element that receives attention after a user action. In HTML there are three means to give focus to an element:
-</p>
-<ul>
-
-    <li>Activating the element with a pointing device (mouse)</li>
-    <li>Activating the element with the Tab key</li>
-    <li>Activating the element with a keyboard shortcut (<code>accesskey</code>)</li>
-
-</ul>
-<p>Elements that receive focus natively are: <code>a</code>, <code>area</code>, <code>button</code>, <code>input</code>, <code>object</code>, <code>select</code>, <code>label</code>, <code>legend</code>, <code>optgroup</code>, <code>option</code> and <code>textarea</code>. The element's behaviour, when it is focused, depends on its nature; a link, for example, must be activated afted it has been focused (except when a script is used). On the other hand, a form element, such as <code>textarea</code>, must allow input after it has received focus. The <code>label</code> and <code>legend</code> elements can only receive focus via the mouse pointer. For the <code>label</code> element, the expected behavior is to transfer focus to the form field it is associated with.
-</p>
-<p><strong>Note 1:</strong> The WAI-ARIA specification extends the role assigned to the <code>tabindex</code> attribute, by defining that any HTML element can become focusable by setting <code>tabindex</code> at 0. However, no behavior is defined if <code>tabindex</code> is declared but has no set value. Setting an element's <code>tabindex</code> at -1 (minus one) removes this element from the tabbing order, inhibiting its ability to signal it has gained focus. Using <code>tabindex</code> accordingly with the WAI-ARIA specification can validate some tests related to focus management.
-</p>
-<p><strong>Note 2:</strong> the focus visual cue must not be degraded, meaning that its visibility is lessened compared to the user agent's default style.
-</p>
-
-<h3 id="mFooter">
-Footer
-</h3>
-<p>
-Container of information related to the use of the site, or legal information. This is generally where can be found links to the help page, the credits page, terms of use, and the accessibility page, potentially.
-</p>
-
-<p><strong>Note:</strong> this page footer area, unique in a page, must not be mistaken with footers of sections, defined in HTML5 with the <code>footer</code> tag.
-</p>
-<p>See the technical definition as defined by the ARIA API: <a href="https://www.w3.org/WAI/PF/aria/roles#contentinfo">Contentinfo (role)</a>.
-
-<h3 id="mEtiquette">
-Form field label
-</h3>
-
-<p>Text located next to the form field describing the nature, type or format of expected input. The label can be associated with the form field in several ways: with a <code>label</code> tag, an <code>aria-label</code> property, an <code>aria-labelledby</code> property and its related text, a <code>title</code> attribute.
-</p>
-<h3 id="mChpSaisie">
-Form input field
-</h3>
-<p>
-Object, in a form, allowing the user:</p>
-<ul>
-<li>to enter text or pre-formatted data:
-  	<ul>
-        <li><code>input type="text"</code>;</li>
-        <li><code>input type="password"</code>;</li>
-        <li><code>input type="search"</code>;</li>
-        <li><code>input type="tel"</code>;</li>
-        <li><code>input type="email"</code>;</li>
-        <li><code>input type="number"</code>;</li>
-        <li><code>input type="tel"</code>;</li>
-        <li><code>input type="url"</code>;</li>
-        <li><code>textarea</code>;</li>
-    </ul>
-</li>
-    <li>to select predefined values:
-        <ul>
-        	<li><code>input type="checkbox"</code></li>
-        <li><code>input type="radio"</code></li>
-        <li><code>input type="date"</code></li>
-        <li><code>input type="range"</code></li>
-        <li><code>input type="color"</code></li>
-        <li><code>input type="time"</code></li>
-        <li><code>select</code></li>
-        <li><code>datalist</code></li>
-        <li><code>optgroup</code></li>
-        <li><code>option</code></li>
-        <li><code>keygen</code></li>
-    </ul>
-</li>
-    <li>to download files:
-     <ul>
-     	   <li><code>input type="file"</code></li>
-     	</ul>
-    </li>
-    <li>or to display results:
-     <ul>
-        <li><code>output</code></li>
-        <li><code>progress</code></li>
-        <li><code>meter</code></li>
-     	</ul>
-    </li>
-</ul>
-<p>The following form objects are not considered as form fields:</p>
-
-    <ul>
-    	<li><code>input type="submit"</code></li>
-    <li><code>input type="reset"</code></li>
-    <li><code>input type="hidden"</code></li>
-    <li><code>input type="image"</code></li>
-    <li><code>input type="button"</code></li>
-    <li><code>button</code></li>
-</ul>
-
-<h3 id="mTitreCadre">
-Frame title
-</h3>
-
-<p>Value of the <code>title</code> attribute of the  <code>iframe</code> tag, describing the nature of the content provided via the inline frame, useful when navigationg from frame to frame, or displaying the list of frames in the page, for example.
-</p>
-<p><strong>Note 1:</strong> some inline frames only have a purely technical purpose, like preprocessing content displayed in the page (commonly found for social networks widgets like Facebook's, for instance).
-</p>
-<p>If the remote content inside the frame has no title, or if it is  not relevant, generic indications may be used, like for example: "Facebook: technical contents".</p>
-<p><strong>Note 2:</strong> If there is no impact on the functionality, these contents may be hidden to assistive technologies, via the <code>aria-hidden</code> attribute, for instance.</p>
-
-<ul class="navTheme">
-	<li><a href="#f">Skip to F</a></li>
-	<li><a href="#i">Skip to I</a></li>
-</ul>
-<h2 id="h">H</h2>
-<h3 id="mCelluleTab">
-Header cells (of a table)
-</h3>
-<p>
-Cells of a data table (first cell in a row or a column, generally), serving as a title for all, or some of, the row or column other cells. A column or a row can have several headers (intermediary headers). Header cells must be coded with a <code>th</code> tag.
-</p>
-
-<h3 id="mTitre">
-Heading
-</h3>
-
-<p>HTML element (h<i>n</i> tag) with 6 hierarchy levels (from <code>h1</code> for the most important heading to <code>h6</code> for the less important), allowing to define and title sections in a Web content. The hierarchy between headings must be respected on a Web page, and the heading levels cannot be skipped: a <code>h3</code> heading (level 3) cannot be the next heading after a <code>h1</code> heading (level 1), for example. On each Web page, there must be at least one <code>h1</code> heading.</p>
-
-<p><strong>Note:</strong> Headings hidden via CSS are considered as available to the user, and validate criterion 9.1.
-</p>
-<h3 id="mTexteCache">
-Hidden text
-</h3>
-
-<p>Assistive technologies (in particular, screen readers) do not render content hidden via these properties:
-</p><ul>
-
-    <li>(CSS) <code>display:none</code>;</li>
-    <li>(CSS) <code>visibility:hidden</code></li>
-    <li>(CSS)<code>width=0; height=0;</code></li>
-    <li>(HTML) <code>width=0</code> and <code>height=0</code></li>
-    <li>(CSS) <code>font-size:0;</code></li>
-    <li>(CSS) <code>clip:0;</code></li>
-    <li>(HTML5) <code>hidden</code> attribute;</li>
-    <li>(HTML+ARIA) <code>aria-hidden=true</code></li>
-
-</ul>
-<p>All text content using one or more of these properties are scoped by the criterion 10.13.</p>
-
-<ul class="navTheme">
-	<li><a href="#h">Skip to H</a></li>
-	<li><a href="#l">Skip to L</a></li>
-</ul>
-<h2 id="i">I</h2>
-
-
-
-<h3 id="mImgDeco">
-Image (decorative)
-</h3>
-
-<p>An image that has no purpose and that does not convey any particular information regarding the content it is associated with. Examples:
-</p>
-<ul>
-	<li>An image used for layout adjustments only,</li>
-    <li>an image of a rounded corner, used to style a block,</li>
-    <li>an illustrative image that does not provide any information that helps understanding the text it is associated with.
-</li>
-
-</ul>
-
-<h3 id="mImgObj">
-Image (object image)
-</h3>
-<p>
-Image inserted or generated via an <code>object</code> tag.
-</p>
-
-
-<h3 id="mImgTextObj">
-Image (object text image)
-</h3>
-<p>
-Image implemented via the <code>object</code> tag and displaying text.
-</p>
-
-<h3 id="mImageCaption">
-Image caption
-</h3>
-<p>For an image, a caption is an adjacent text, containing information about the image (for instance a copyright, a date, an author&hellip;), or information complementary to the one conveyed by the image (for instance, text associated with an image in a gallery).</p>
-<p>When an image has a caption, it is necessary to tie the image and its caption together via a structure relationship, so that assistive technologies can process both as a whole.
-</p>
-<p>The HTML5 specification defines the <code>figure</code> (container for the image and its caption) and <code>figcaption</code> (container for the caption) tags.
-</p>
-<p>An image without caption can be:
-</p>
-<ul>
-  <li>an image that is not included in a <code>figure</code> element;</li>
-<li>an image included in a <code>figure</code> element, with no <code>figcaption</code> element</li>
-
-</ul>
-
-<p>Note: when the text adjacent to the image can serve as its alternative text, it is not required to use <code>figure</code> and <code>figcaption</code> tags; the image can be considered as decorative in this situation.
-</p>
-
-<h3 id="mImgInfo">
-Image conveying information
-</h3>
-<p>An image that conveys information needed to understand the content it is associated with.
-</p>
-
-<h3 id="mInfoDonneeCouleur">
-Image conveying information (provided by color)
-</h3>
-<p>Image for which all or part of its content conveys information visually, by means of color only.
-</p>
-
-<h3 id="mLienImage">
-Image link
-</h3>
-<p>
-Link whose content between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> is only constituted of an image. The link text of an image link is the content of the  text alternative of the image.
-</p>
-<p><strong>Note:</strong> an image link may be based on an image (<code>img</code> tag), an object image (<code>object</code> tag) or a bitmap image (<code>canvas</code> tag).</p>
-
-<h3 id="mImgReactive">
-Image map
-</h3>
-<ol>
-	<li>    <strong>client-side image map</strong> (<code>usemap</code> attribute): image divided into clickable or non-clickable areas (<code>nohref</code> attribute).
-	</li>
-	<li>    <strong>Server-side image map</strong> (<code>ismap</code> attribute) : image for which the browser sends the coordinates of the pointing device to the server, each set of coordinates corresponding to a resource (URL). The server-side image map is extremely rare.
-	</li>
-</ol>
-<p>
-Note: in HTML5, the <code>ismap</code> attribute is obsolete non conformant for form buttons of type image (<code>input type="image"</code>).
-</p>
-
-<h3 id="mImgText">
-Image of text
-</h3>
-<p>
-Image that displays text.
-</p>
-
-<h3 id="mInfoCouleur">
-Information conveyed by color
-</h3>
-
-<p>Information that is visually conveyed by means of color. Indication that the required fileds of a form are in red; a change of background color to indicate the current page in a navigation menu; a change of text color to indicate that an article is unavailable, inside a list of articles; are all examples of information conveyed by color.</p>
-<p>Information conveyed by color must be completed with another means of conveying information, that does not rely on visual perception, for users who do not perceive, or not well enough, colors and their combinations.</p>
-<p>It is recommended to use additional text content, or images with appropriate text alternatives, to satisfy this requirement. Purely visual effects (change of style, size, boldness, typography, etc.) would not be considered sufficient, since they would not be perceived by users who do not have access to the graphical version of the page.</p>
-
-<h3 id="mInfoShape">
-Information conveyed by shape, size or location
-</h3>
-
-  <p>It can be, for instance:</p>
-  <ul>
-<li>a visual cue, to indicate the current page in a navigation menu (information conveyed by position),
-</li>
-<li>a visual effect to make the active tab in a tablist appear like it is in the foreground (information conveyed by shape);
-</li>
-<li>a change in text size in a tag cloud (information conveyed by size).
-</li>
-  </ul>
-<p>Or any other similar effect.</p>
-
-
-<h3 id="mInfoMNature">Information of same nature</h3>
-<p>
-In a form, a set of fields that can be considered as a group because of the nature of the expected input.</p>
-<p>Examples:</p>
-  <ul>
-<li>Three consecutive fields to enter a date (year/month/day);</li>
-<li>Consecutive fields for a phone number;</li>
-<li>Fields for the name and address, when several similar blocks of input fields are available in the same form;</li>
-<li>A set of radio buttons or checkboxes related to a question asked.</li>
-</ul>
-<p>These fields must be grouped together via a <code>fieldset</code> tag, and a relevant <code>legend</code> tag. In the case of radio buttons, generally, the legend is the question text.</p>
-<p>
-  <strong>Note:</strong> When the form consists in only one block of input fields of same nature (user name and address, for example) or one single field (a search engine input field, for example), the <code>fieldset</code> tag is not required.</p>
-
-<h3 id="mPresInfo">
-Information presentation
-</h3>
-
-<p>Visual rendering of content via a graphic browser. Presentation concerns style, position and dimensions of HTML elements and their content. Information presentation must be performed with CSS. Are prohibited these elements: <code>basefont</code>, <code>blink</code>, <code>center</code>, <code>font</code>, <code>marquee</code>, <code>s</code>, <code>strike</code>, <code>tt</code>, <code>u</code>; and these attributes: <code>align</code>, <code>alink</code>, <code>background</code>, <code>basefont</code>, <code>bgcolor</code>, <code>border</code>, <code>color</code>, <code>link</code>, <code>text</code>, <code>vlink</code>. The <code>width</code> and <code>height</code> attributes used on other elements than images (<code>img</code> tag) are also prohibited. </p>
-
-<h3 id="mCadreEnLigne">
-Inline frame
-</h3>
-<p>
-HTML element (<code>iframe</code> tag) providing a way to display contents from another page, inside the current web page.
-</p>
-
-<h3 id="mControleSaisie">
-Input control (form)
-</h3>
-
-<p>All the processes designed to inform the user about required fields, expected types and formats, and  input errors in a form. These controls can be implemented by the content author, or rely upon HTML attributes (like <code>required</code> or <code>pattern</code>), WAI-ARIA properties (like <code>aria-required</code>) or field types automatically generating input indications or error messages (like <code>url</code>, <code>email</code>, <code>date</code>, <code>time</code>, for example).
-</p>
-<p>Important: after form submission with input errors, if an error handling page is displayed, the page title must include a mention like "input errors in the form".</p>
-
-
-<ul class="navTheme">
-	<li><a href="#i">Skip to I</a></li>
-	<li><a href="#m">Skip to M</a></li>
-</ul>
-<h2 id="l">L</h2>
-<h3 id="mLanguageChange">Language change</h3>
-<p>An indication of language change tells user agents which language-specific rules should be applied to render appropriately parts of the content   written in a human language different from the main language of the content. This includes, notably, the vocal restitution performed by speech synthesizers. Language changes apply to all contents, including some attributes like <code>title</code>.</p>
-<p><strong>Note:</strong> in HTML, it is not technically possible to signal language changes inside an attribute value. In this case, the language change is signalled via the element bearing this attribute. For instance, an hyperlink with a <code>title</code> attribute in German, in a page whose main language is English, should have a <code>lang</code> attribute set to <code>"de"</code>. When the attribute contains several language changes, the criterion is not applicable.
-</p>
-
-<h3 id="mCodeLangue">
-Language code
-</h3>
-
-<p>Code with two characters (ISO 639-1) or 3 characters (ISO 639-2 and following) specifying the default language of a document or a chunk of text. The language code  is constituted of two parts separated by a dash on the model <code>lang="[code][-option]</code>".
-</p>
-    <ul>
-    	<li>[code] represents a valid language code of 2 or 3 characters;</li>
-    <li>[option] is an indication left to the author's judgment.</li>
-
-</ul>
-<p>When the [option]  is provided, it defines a language regionalisation. For example: <code>"en-us"</code> for American English. When checking for conformance against the RGAA, only the [code] part is evaluated.</p>
-
-
-<h3 id="mLien">
-Link
-</h3>
-
-<p>HTML element (<code>a</code> tag) that can be activated by the user (with the mouse, the keyboard&hellip;) and that initiates an action (generally, a page or file download) or an event generated by a script. A link has at least:
-</p>
-    <ul>
-      <li>a resource reference (<code>href</code> attribute);</li>
-    <li>a link text between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>.</li>
-
-</ul>
-<h3 id="mLienComposite">
-Link (Combined)
-</h3>
-
-<p>Link whose content between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> is formed with at least 2 elements of different types; for example, text and one or several images. The link text of a combined link is the whole text and the content of the text alternatives of the image(s)  between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>.
-</p>
-<p>Important notice: having two identical adjacent links (image and text links, for instance, with the same purposes, URL and link text) is a significant inconvenience for some users? Even though this is not a non-conformity, this practice should be avoided. A way to implement this kinfd of links is to include the image into the text link, in order to obtain a combined link.</p>
-
-<p>On this subject, you may read this WCAG Technique: <a href="http://www.w3.org/TR/WCAG20-TECHS/H2.html">H2 : Combining adjacent image and text links for the same resource</a>.
-</p>
-
-<h3 id="mContexteLien">
-Link context
-</h3>
-
-<p>The link context represents additional information that can be programmatically determined from relationships with a link, combined with the link text, and presented to users in different modalities. Programmatically determined contexts that can make a link explicit are the following:
-</p>
-
-<ul>
-	    <li>The content of the sentence enclosing the link;</li>
-    <li>The content of the paragraph (<code>p</code> tag) containing the link;
-    </li>
-    <li>The content of the list item (<code>li</code> tag), or the content of a parent list item (<code>li</code> tag) of the list item,  containing the link;
-    </li>
-    <li>The content of the heading (<code>h1</code> to <code>h6</code> tags) that is the  closest ascendant of the link;
-    </li>
-    <li>The content of the table header cell(s) (<code>th</code> tags)  associated with the table data cell (<code>td</code> tag) containing the link;
-    </li>
-    <li>The content of the table data cell (<code>td</code> tag) containing the link;
-    </li>
-    <li>The content of the link title (<code>title</code> attribute);
-</li>
-<li>The content of the <code>aria-label</code> property;</li>
-<li>The content of the chunk(s) of text associated with the link via the <code>aria-labelledby</code> property.</li>
-</ul>
-<p><code>Note 1:</code> One of the 9 link contexts alone must be sufficient to make the link explicit.</p>
-<p><strong>Note 2:</strong> The RGAA considers that specific links like <code>mailto</code> links (interpreted by the user agent as a clickable e-mail address) are explicit by nature. therefore it is not required to inform the user, via a link title for instance, that the link triggers the opening of an e-mail client application. Authors are advised, however, to adapt this rule to the situation. For instance, if the page contains multiple clickable e-mail addresses, some opening thee-mail client application, other sending to a contact form, then it may be necessary to provide additional information in order to help the user understand the different uses of this type of links in this context.</p>
-
-<h3 id="mLienIdentique">
-Links (Identical)
-</h3>
-
-<p>Two links are considered identical when link x (link text only, content of the <code>title</code> attribute or link context) is equal to link y. This definition applies to all types of links: text links, image links (identical images) and combined links.</p>
-
-<p><strong>Warning:</strong> links with identical texts but with different link titles or different link contexts are not identical. Example of non-identical links: <code>&lt;a href="link_bar.html" title="click here to download the toolbar"&gt;click here&lt;/a&gt;</code> and <code>&lt;a href="link_doc.html" title="click here to download the document"&gt;click here&lt;/a&gt;</code>).
-</p>
-
-<h3 id="mIntituleLien">
-Link text
-</h3>
-<p>
-Textual information contained between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> of a link completed if necessary with context information.</p>
-<p> The four different types of links are:</p>
-</p>
-<ul>
-    <li>text link: text between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>, completed, if necessary, with context information;
-    </li>
-    <li>image link: text alternative(s) of the image(s) between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>, completed, if necessary, with context information;
-    </li>
-    <li>combined link: text, and text alternative(s) of the image(s) between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>, completed, if necessary, with context information;
-    </li>
-    <li>vector link: text alternative of the vector image (<code>svg</code> tag) between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> completed, if necessary, with context information.
-    </li>
-</ul>
-
-<p><strong>Note 1:</strong> An image link can be based on an image (<code>img</code> tag), on image object (<code>object</code> tag) or a bitmap image (<code>canvas</code> tag).
-</p>
-
-<p><strong>Note 2:</strong> An image link with a missing <code>alt</code> attribute is considered as not applicable for criterion 6.5.
-</p>
-
-<h3 id="mTitreLien">
-Link title
-</h3>
-<p>
-Content of the <code>title</code> attribute of a link. This content must be set only if it is necessary to identify the link target in an explicit way. A link title must duplicate the link text, and add  complementary information. A link title will be considered as not relevant in the following situations:</p>
-
-<ul>
-      <li>The link title is empty (<code>title=""</code>)</li>
-    <li>The link title is identical to the link text (see note 1)</li>
-    <li>The link title does not include the link text</li>
-
-</ul>
-<p><strong>Note 1:</strong> By exception, a link title identical to the link text is  tolerated in the case of an image link (a link that only contains images), like a clickable icon, for example.
-</p>
-<p>Authors are warned that relying upon the <code>title</code> attribute to convey information is unsafe. Specifically, contents in <code>title</code> attributes are not rendered visually when navigating with the keyboard, a tactile interface, or when an assistive technology user settings prevent them from being rendered. therefore, they should be used only as a last resort solution.</p>
-
-
-<h3 id="mLienNature">
-Link whose nature is not obvious
-</h3>
-
-<p>Link that can be confused with normal text, when it is indicated through color alone, by some types of users who have bad or no color perception. For example, in this text "New strike at SNCF", if the word "strike" is a link that is specified by color alone, its kind can be ignored by users who cannot perceive color and who access content with CSS enabled. On the other hand, in this text "New strike at SNCF, read more" if "read more" is a link, a user who does not perceive colors will have no difficulties to understand its nature.
-</p><p>
-<strong>Note:</strong> "indicated through color alone" means that the link is accompanied by no other visual indication (icon, underline, border&hellip;). As a consequence, a link of the same color as the surrounding text is targetted by this criterion.
-</p>
-
-<h3 id="mListes">
-Lists
-</h3>
-
-<p>Sequence of elements that can be grouped in the form of a structured list as ordered, unordered or definition lists. For example, the  links in a navigation menu is an unordered list of links, the different steps in a process are an ordered list of items, the pair term/definition in a glossary is a definition list. In HTML, lists are defined using the following tags:
-</p>
-    <ul>
-      <li>ordered list: <code>ol</code> and <code>li</code> tags (each list item is numbered incrementally)
-</li>
-<li>    unordered list: <code>ul</code> and <code>li</code> tags (each list item is, potentially, marked with a bullet point)
-</li>
-<li>    definition list: dl, dt: term(s) to be defined, and dd: definition data
-</li>
-
-</ul>
-
-<ul class="navTheme">
-	<li><a href="#l">Skip to L</a></li>
-	<li><a href="#n">Skip to N</a></li>
-</ul>
-<h2 id="m">M</h2>
-<h3 id="mMain">
-Main content area
-</h3>
-<p>
-Container of the main contents of the page, where can be found principal information and functionalities (therefore excluding menu, the search form, or secondary content blocks contaning related news, ads, etc.).
-</p>
-
-<p><strong>Note:</strong> there must be only one main content area. On some pages, defining what constitutes the main content can be challenging, like on homepages for instance.
-</p>
-<p>See the technical definition as defined by the ARIA API: <a href="https://www.w3.org/WAI/PF/aria/roles#main">Main (role)</a>.
-
-<ul class="navTheme">
-	<li><a href="#m">Skip to M</a></li>
-	<li><a href="#o">Skip to O</a></li>
-</ul>
-<h2 id="n">N</h2>
-
-<h3 id="mNameRole">
-Name, role, value, settings and states changes
-</h3>
-<p>A user interface component must have appropriate role and name; its values, states and parameters (if any) must also be available and correctly conveyed to accessibility APIs, in particular.</p>
-<p>The name may be the component's text content, like the label of a button, for example. </p>
-<p>The value may be the selected item of a select list, or the current value of a slider, for example.</p>
-
-<p>The role of an element is defined by the HTML specification (native roles, like for the button tag for example) or the WAI-ARIA API (ARIA role="button", for example).
-</p>
-
-<p>The settings are the information specific to a component, generally defined via the WAI-ARIA API. For example, <code>aria-controls</code> is a parameter informing the APIs that the component controls another one (referenced via its <code>id</code> attribute).
-</p>
-
-<p>The states changes are generally conveyed via the WAI-ARIA API. For instance <code>aria-expanded</code> is a state informing the accessibility APIs that the component is "expanded" or "collapsed". <strong>Note:</strong> a state can also be conveyed by the name, when it is dynamically changed to match the current state of the component, for instance.
-</p>
-<p>These parameters are not mandatory, but may be required if they are needed to make the component accessible. When testing for accessibility, the assessor must decide, based on the context where the component is used, if these parameters are required.</p>
-<p>The assessor must also check that they are implemented according to the specifications, when they are used.</p>
-<p><strong>Note:</strong> the ARIA roles, properties and states are implemented via attributes, like <code>role="banner"</code>, or <code>aria-hidden="true"</code> for instance.</p>
-
-
-
-<h3 id="mBarreNav">Navigation bar</h3>
-<p>
-
-List of links providing a means to navigate in the website, in a category or in a collection of pages. The main navigation bars are:</p>
-<ul>
-    <li>The main navigation menu</li>
-    <li>A breadcrumb trail</li>
-    <li>A navigation list of a results list</li>
-    <li>The menu of a subcategory</li>
-</ul>
-</p>
-<h3 id="mMenuNav">
-Navigation area, Navigation menu
-</h3>
-
-<p>Area with a list of links, giving access to the main parts of the website. Most of times, the navigation menus are the main and secondary menus.
-</p>
-<p>Note: links found in the footer, pointing to the credits page, the legal information page, the sitemap, and other site-related information pages, are not considered as a navigation menu.</p>
-<p>See the technical definition of a navigation area provided by the WAI-ARIA API: <a href="http://www.w3.org/WAI/PF/aria/roles#navigation">navigation (role)</a>.</p>
-
-
-<h3 id="mSysNav">
-Navigation system
-</h3>
-
-<p>Any process allowing to navigate in the website or in a page. In the RGAA, the considered  navigation systems are:
-</p>
-    <ul>
-      <li>Main navigation menu</li>
-    <li>Table of contents</li>
-    <li>Site map</li>
-    <li>Search engine</li>
-
-</ul>
-
-<h3 id="mMediaNoTemp">
-Non time-based media
-</h3>
-<p>
-Content that is not time-dependant, that can be played via a plugin (Flash, Java, Silverlight&hellip;) or via <code>svg</code> and <code>canvas</code> tags. For example, an interactive map in Flash, a Flash-based or Java application, a user-controlled slideshow, are non time-based media. A non time-based media can contain time-based media (a Flash-based gallery of videos, for example).</p>
-
-<p><strong>Note :</strong> the use of the <code>wmode</code> parameter for a Flash object with the values "<code>transparent</code>" and "<code>opaque</code>" invalidates criterion 4.21 (Can each non time-based media be controlled by the keyboard and by the mouse?). When accessed with a  screenreader, these values make the Flash movie inaccessible (the object is ignored, or can not be browsed). therefore it can not be tabbed to.</p>
-
-<ul class="navTheme">
-	<li><a href="#n">Skip to N</a></li>
-	<li><a href="#p">Skip to P</a></li>
-</ul>
-<h2 id="o">O</h2>
-<!-- Only for layout -->
-<h3 id="mUniquPres">
-Only for layout
-</h3>
-
-<p>Only for layout: use of HTML tags for a purpose  different from what  is intended by specifications (with regard to the declared document type). Examples: use of <code>H<i>n</i></code> tags only to apply tyhe associated typographical effect; use of the <code>blockquote</code> tag only to indent a block of text, etc.</p>
-  <p><strong>Note 1:</strong> the use of DIV or SPAN elements for paragraphs is considered as a non conforming use of these elements, and invalidates the criterion.
-</p>
-<p><strong>Note 2:</strong> WAI-ARIA provides the <code>presentation</code> role, which suppresses the semantics of an element. For example: <code>&lt;h1 role=presentation"&gt;Title&lt;/h1&gt;</code>. In this example, the text content will be rendered, but not the role of heading (the rendered element will be undefined, in the form of <code>&lt;&gt;Title&lt;&gt;).</code></p>
-<p>The <code>presentation</code> role may be required for some ARIA design patterns.It can also be used to suppress semantics on an element used only for layout. For example: <code>&lt;blockquote role=presentation"&gt;</code> will have the same effect as an absence of <code>blockquote</code> element.  </p>
-<p>Although authors are strongly advised against this technique (because it will fail for older assistive technologies that do not support ARIA, for instance), it can be considered as WCAG conformant. However, assigning a <code>presentation</code> role to an element whose nature (i.e., its semantics) is essential to understand the content, is a viloation of the WCAG recommendations (see <a href="https://www.w3.org/TR/2015/NOTE-WCAG20-TECHS-20150226/F92">Failure F92</a>) et invalidates the criterion.</p>
-
-<ul class="navTheme">
-	<li><a href="#o">Skip to O</a></li>
-	<li><a href="#r">Skip to R</a></li>
-</ul>
-<h2 id="p">P</h2>
-
-<h3 id="#PageHeader">
-Page Header
-</h3>
-
-<p>
- Also called banner. Content block, starting a web page, and containing generally the document's headline, a logo, a baseline&hellip;
-</p>
-
-<p><strong>Note:</strong> this header must not be mistaken with section headers, which can be defined in HTML5 with the <code>header</code> tag in any sectioning element.
-</p>
-<p>See the technical definition of a banner as defined by the ARIA API: <a href="https://www.w3.org/WAI/PF/aria/roles#banner">Banner (role)</a>.
-</p>
-<h3 id="#mFontSize">
-Percentage of the default font size
-</h3>
-<p>150% and 120% of the default font size: these two dimensions define the relative font size equivalent to 18 point (non-bold), and 14 points (bold), respectively, considering that the body font size is set at 100%.
-</p>
-<p>
-The default font size is defined by the author for the document body; and if not specified, the default font size for the user agent (a browser, generally). In most current browsers, the default font size is set at 16 pixels.
-</p>
-
-<h3 id="mDOM">
-Properties and methods compliant with the DOM (Document Object Model) specification</h3>
-<p>The content insertion methods compliant with the DOM specification use properties and methods of the Node object, as opposed to proprietary methods; for example <code>document.write</code>, specific to the Internet Explorer/Microsoft, for legacy IE browsers.
-</p>
-<ul class="navTheme">
-	<li><a href="#p">Skip to P</a></li>
-	<li><a href="#s">Skip to S</a></li>
-</ul>
-<h2 id="r">R</h2>
-<h3 id="mSensLecture">
-Reading direction
-</h3>
-
-<p>Indicates the reading direction of the document or of a chunk of text via the <code>dir</code> attribute. The three accepted values are:</p>
-
-    <ul>
-     <li> <code>ltr</code> (left to right) indicates a reading direction from the left to the right;</li>
-    <li><code>rtl</code> (right to left) indicates a reading direction from the right to the left;
-</li>
-<li><code>auto</code>, which lets the browser determine the reading direction based ont the Unicode characters it finds in content.</li>
-</ul>
-<p><strong>Note:</strong> When the dir attribute is not set, the default reading direction is from left to right ("ltr" value).
-</p>
-
-
-
-<h3 id="mProcedeRafraichissement">
-Refresh process
-</h3>
-<p>
-Technique aiming at modifying the content of one or several elements of the Web page. The refresh process can be performed by automatic reloading of the page, or in a dynamic way without reloading the page (via AJAX, for example). The user must be able to control each refresh process in an independent way.</p>
-
-<h3 id="mPertinence">
-Relevance (information not conveyed through color only)
-</h3>
-
-<p>The means to retrieve information other than through color must be accessible for all. For example, in the case of a list of articles where articles with texts in yellow are discounted, the use of hidden text via CSS is a means to retrieve information "discounted", but it is not relevant because this information will remain hidden for users who browse the page with CSS enabled.
-</p>
-<p><strong>Note:</strong> The use of an emphasis tag (<code>strong</code> or <code>em</code>) as another means to retrieve information conveyed by color, validates the criterion, although these elements are generally not supported by assistive technologies, including screen readers.
-</p>
-<ul class="navTheme">
-	<li><a href="#r">Skip to R</a></li>
-	<li><a href="#t">Skip to T</a></li>
-</ul>
-<h2 id="s">S</h2>
-
-<h3 id="#mScript">
-Script
-</h3>
-<p>Computer code generally presented as  a list of instructions (in JavaScript, for example). Client-side scripting languages require a compatible browser where they are enabled. The instructions of a  client-side scripting language can be either embedded  in the HTML code, or fetched from  an external file. In both cases, scripts are included  via  <code>script</code> tags.
-</p>
-
-
-<h3 id="mMoteurRecherche">
-Search engine (internal to a website)
-</h3>
-<p>Component of the site with which the user can perform searches on all the site's contents.
-</p>
-<p><strong>Note:</strong> this site-scaled search engine should not be confused with other search engines specific to a subparts of the site's contents, like the products of an online catalogue, or the list of public calls for tenders on a purchasing platform.
-</p>
-<p>See the technical definition of a search engine as defined by the ARIA API: <a href="https://www.w3.org/WAI/PF/aria/roles#search">search (role)</a>.
-</p>
-
-
-<h3 id="mListeChoix">
-Selection list
-</h3>
-
-<p>Form field designed to select  items in a pull-down list (<code>select</code> tag with <code>option</code> tags).</p>
-
-<h3 id="mEnsemblePages">
-Set of pages
-</h3>
-
-<p>Pages linked to each other through links, and constituent a consistent set inside of a website. For example, the pages of an electronic payment process, the pages of a specific category, the pages of a blog, the pages to manage an account are sets of pages.
-</p>
-<p> <strong>Note:</strong> A website's home page can be considered as a "set of pages" (with only one element), as it can be quite  different from the rest of the site.
-</p>
-
-<h3 id="mPlanSite">
-"Site map" page
-</h3>
-
-<p>Dedicated page presenting the structure of a Web site, generally as lists of categories and subcategories, with links giving access to al the site's pages.
-</p>
-<p><strong>Note 1:</strong> the site map's links may be implemented with <code>a</code> or <code>area</code> tags.
-</p>
-<p><strong>Note 2:</strong> it is not necessary that the site map lists the links to all the site's pages; however, starting from the site map page, the user should be able to reach every page on the site.
-</p>
-
-<h3 id="mTexteStyle">
-Styled text
-</h3>
-
-<p>Text for which presentation is entirely controlled by a style properties, as opposed to by presentational tags.</p>
-
-<h3 id="mCompAccess">
-Supported by assistive technologies
-</h3>
-
-<p>A content or a functionality must be supported by users' assistive technologies, as well as the accessibility features in browsers and other user agents via an accessibility API.
-</p>
-
-<p>This concerns the technology, its features and its uses at the same time:</p>
-
-<ul>
-	   <li> The way the  technology is used must be supported by users' assistive technology. This means that the way  the technology is used has been tested for interoperability with users' assistive technologies in the human language(s) of the content,</li>
-    <li>the technology is supported natively in widely-distributed user agents that are also accessibility supported (such as HTML and CSS) or in a widely-distributed plugin that is also accessibility supported.</li>
-
-</ul>
-Checking for support by assistive technologies requires to perform  tests that are specific to the technology used. For instance:
-<ul>
-
-    <li>checking the name, role, value and states changes of user interface components;</li>
-    <li>checking that a user interface component is correctly rendered by the considered assistive technologies.</li>
-
-</ul>
-<h3 id="mFeuilleStyle">
-Style sheet
-</h3>
-
-<p>Set of instructions, written in CSS, a standardized language used to defined the layout of content elements in an HTML document (examples: page background color, text size/font/color, position in the page&hellip;). Style sheets can be external (CSS file), embedded (declared in the <code>head</code>) or inline (declared via the <code>style</code> attribute of a tag).
-</p>
-<h3 id="mResumeTab">
-Summary (of a table)
-</h3>
-<p>A table summary is a chunk of text associated with a complex data table. It provides information on the nature and structure of the table, in order to ease its consultation for users of assistive technologies, for instance.
-</p>
-<p><strong>Note:</strong> the <code>summary</code> attribute is obsolete non conformant in HTML5, and must not be used anymore.
-</p>
-<p>
-Among the 5 techniques proposed by the HTML5 specification, the only one that should be used currently consists in inserting the summary in the table title (<code>caption</code> tag), and hiding it with CSS if necessary.
-</p>
-<p>
-Read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit5-1">Technical note on table summaries</a>.
-</p>
-
-<h3 id="mSsTitreSynchro">
-Synchronised captions (media object)
-</h3>
-
-<p>Synchronized visual and/or text alternative for both speech and non-speech audio information (including spoken dialogue, but also equivalents for non-dialogue audio information needed to understand the program content, including sound effects, music, laughter, speaker identification and location), needed to understand the media content.</p>
-<p> <strong>Note 1:</strong> In order to differentiate audio sources (different speakers, voice off screen&hellip;), it is recommended to use an appropriate mechanism (square brackets, italics, explicit mention like "voice off screen:&hellip;").</p>
-<p><strong>Note 2:</strong> captions should not be mistaken with subtitles, although both words may be used for the same usage in some countries. "Captions" (<code>kind="captions"</code> in HTML5) refer to  alternatives aiming at fulfilling the needs of people who are deaf or hard-of-hearing, while "subtitles" (<code>kind="subtitle"</code> in HTML5) refer to translation of spoken content in a different human language. Only captions will be considered to check conformance against the RGAA.
-</p>
-<ul class="navTheme">
-	<li><a href="#s">Skip to S</a></li>
-	<li><a href="#u">Skip to U</a></li>
-</ul>
-<h2 id="t">T</h2>
-
-<h3 id="mOrdTab">
-Tabbing order
-</h3>
-
-Order in which the focus moves (to the next element or to the previous element). The natural order is the order of the source code. When it is modified by the use of the <code>tabindex</code> attribute or by scripting, then the modified order is the reference.</p>
-<p> <strong>Warning:</strong> During testing, when an element initiates a change in the document (change of context, management of hidden areas, content addition, management of form fields&hellip;) it is necessary to trigger this change and check that the consistence of the tabbing order is preserved.
-</p>
-
-<h3 id="mTabDonneeComplexe">
-Table (complex data table)
-</h3>
-
-<p>
-<a href="#mTabDonnee"></a>Data tables are considered as complex, in the RGAA, when they have header cells outside of the first row and/or column, or whose scope does not cover the whole row or column. For these tables it is necessary to provide a summary, to describe their nature and structure, in order to ease its consultation by assistive technologies users, in particular.
-</p>
-
-<h3 id="mTabDonnee">
-Table (data table)
-</h3>
-
-<p>HTML element (<code>table</code> tag) allowing to structure data in rows and columns via data cells (<code>td</code> tag) and header cells (<code>th</code> tag).
-</p>
-
-<h3 id="mTabMiseForme">
-Table (for layout)
-</h3>
-
-<p>Web design technique based on the TABLE and TD elements to position  contents on screen.
-</p>
-
-<h3 id="mImgTest">
-Test image
-</h3>
-
-<p>Image used in a test, a <a href="#mcaptcha">CAPTCHA</a> or an image used for a test in a quiz or a game. Example: a series of images present a detail from famous paintings; the title and the painter of each painting must be found. In this case, it is not possible to provide a relevant alternative (e.g. the painting title and/or painter) without making the test useless. The alternative must then only provide the ability to identify the image; for example "image 1 of the test".
-</p>
-
-<h3 id="mLienTexte">
-Text link
-</h3>
-
-<p>Link whose content between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> is only constituted of text (called the link text). </p>
-
-<h3 id="mTranscriptTextuel">
-Text transcript (time-based media)
-</h3>
-<p>
-Text content associated with a time-based media through the appropriate technique (text in HTML, or in a text file located in the same page, or accessed via a hyperlink). Without having to play the media content, the user should be able to fully understand it, based on the audio and visual information transcripted. Only significant and useful information (audio and visual) should be included.</p>
-
-<p>This textual information must be presented in the same chronological order as  in the time-based media.
-</p><p>Note: if the media is served via an <code>object</code> tag, then the text transcript must not be inside of the <code>object</code> tag.
-</p>
-
-<h3 id="mMediaTemp">
-Time-based media (sound, video or synchronized)
-</h3>
-
-<ul>
-    <li>Audio-only time-based media: audio content (Wave, MP3&hellip;)</li>
-    <li>Video-only time-based media:  images or pictures moving or played in sequence
-    </li>
-   <li> Synchronised time-based media: audio or video feed synchronised with another time-based media to present information and/or having time-based interactive components. A time-based media can be played in 2 different ways:
-    <ul>
-        <li>  a downloadable file that can be played with a client, third-party software,</li>
-       <li> content embedded in the Web page and that can be played inside the Web page via:
-       <ul>
-         <li>a plugin (example: a video played via a Flash-based player)</li>
-         <li>the <code>video</code> element (a video clip, for instance)</li>
-         <li>the <code>audio</code> element (a podcast, for instance)</li>
-         <li>the <code>svg</code> element (an animated vector movie, for instance)</li>
-        <li>the <code>canvas</code> element (an animated bitmap movie, for instance)</li>
-      </ul>
-     </li>
-
-    </ul>
-  </li>
-
-</ul>
-<p>
-A time-based media can be broadcast live or be provided to play in an asynchronous way (prerecorded media).</p>
-
-<p><strong>Note :</strong> the use of the <code>wmode</code> parameter for a Flash object with the values "<code>transparent</code>" and "<code>opaque</code>" invalidates criterion 4.21 (Can each non time-based media be controlled by the keyboard and by the mouse?). When accessed with a  screenreader, these values make the Flash movie inaccessible (the object is ignored, or can not be browsed). therefore it can not be tabbed to.</p>
-<p>
-Note 2: Animated GIFs, and JavaScript-based animations  are not considered as time-based media with regards to RGAA.</p>
-
-
-<h3 id="mTitreTab">
-Title (of a data table)
-</h3>
-
-<p>Content of an HTML element (<code>caption</code> tag) describing the content of a data table. To be accessible the description must be relevant (clear and concise).
-</p>
-
-<h3 id="mTitrePage">
-Title (of a page)
-</h3>
-
-<p>Content of the <code>title</code> tag of a Web page, describing in a clear, concise and unique fashion, the page content/nature ("site map www.sitename.fr" for a page dedicated to the sitemap of the sitename.fr site, for example).
-</p>
-
-<ul class="navTheme">
-	<li><a href="#t">Skip to T</a></li>
-	<li><a href="#v">Skip to V</a></li>
-</ul>
-<h2 id="u">U</h2>
-<h3 id="mUrl">
-URL
-</h3>
-
-<p>Uniform Resource Locator: a string of characters identifying the location of a resource and secifying the means to act upon it or obtain its representation. Also refered as "web address", on the Web it is applied to identify and provide access to HTML documents, web pages, images, sounds&hellip;
-</p>
-<p><strong>Note:</strong> In the RGAA, the term URL is used instead of URI (Uniform Resource Identifier, a URL being a specific type of URI).
-</p>
-<ul class="navTheme">
-	<li><a href="#u">Skip to U</a></li>
-	<li><a href="#w">Skip to W</a></li>
-</ul>
-<h2 id="v">V</h2>
-<h3 id="mCodeValide">
-Valid code
-</h3>
-<ul>
-	<li>Case of an HTML page: code in which the implementation of tags and attributes repects the specifications of the declared document type.
-<ul>
-	<li><strong>Note 1:</strong> Unless specified, attributes that are not defined in Web standards specifications are not applicable.</li>
-	<li><strong>Note 2:</strong> Unless specified, elements that are not defined in Web standards specifications are not applicable.</li>
-	<li><strong>Note 3:</strong> <a href="http://www.w3.org/TR/xhtml1/#C_3">guideline C3 of the XHTML specification ("Element Minimization and Empty Element Content")</a> states that the use of minimized elements (<code>&lt;elm /&gt;</code>) for empty elements (for example &lt;p /&gt; instead of &lt;p&gt;&lt;/p&gt;) is not advised. This practice constitutes a non-conformance with regards to RGAA.
-	</li>
-</ul>
-
-    <li>Case of a page that implements WAI ARIA: code in which the implementation of tags and attributes follows the specifications of the declared document type and in which WAI ARIA implementation conforms to the WAI ARIA specification.</li>
-
-</ul>
-
-<h3 id="mVectorLink">
-Vector link
-</h3>
-
-<p>Link whose content between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> is only constituted of a vector image (svg tag). The link text of a vector link is the alternative text of the vector image.
-</p>
-
-<h3 id="mVisibleContent">
-Visible content
-</h3>
-<p>For Test 10.2.1: "available content" means that the visible content remains available when CSS styles have been disabled. For instance, an image conveying information, used as a background through CSS, fails this test, since information is not "available" when CSS styles are disabled. However,  an image conveying information, used as a background through CSS, but accompanied by a hidden text, passes this test because information is "available" when CSS styles are disabled.</p>
-<p>
-<strong>Note:</strong> authors are formally advised against using images conveying information as CSS backgrounds, even when hidden texts are available.
-</p>
-<p class="navTheme"><a href="#y">Skip to V</a></p>
-
-<h2 id="w">W</h2>
-<h3 id="mSiteWeb">
-Website
-</h3>
-<p>Set of Web pages:</p>
-    <ul>
-      <li>linked by hyperlinks,</li>
-    <li>belonging to the same domain name (eg.: references.modernisation.gouv.fr),</li>
-    <li>constituting a coherent whole from the user point of view.
-</li>
-</ul>
-<p>Particular case: pages of a subdomain. A subdomain can:</p>
-<ul>
-
-    <li>either belong to the Web site associated with the domain name, if the user has a similar browsing experience as with the other pages of the Web site (for example: same structure, same navigation&hellip;),
-</li>
-<li>    or not belong to the Web site associated with the domain name (for example: a blogging platform where all blogs have their own subdomain of the same domain, but bear no similiraties nor relationships with each other).
-</li>
-</ul>
-
-
-    </main>
-</body>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+
+        <title>RGAA 3.0 Glossary - English translation</title>
+        <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Glossary." name="description" />
+        <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, glossary" name="keywords" />
+
+    </head>
+    <body>
+        <header role="banner">
+            <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
+            <nav id="nav" role="navigation">
+                <ul>
+                    <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
+                    <li><a>Glossary</a></li>
+                    <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
+                    <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
+                    <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
+                    <li><a href="./RGAA3.0_References_English_version_v1.html">References</a></li>
+                </ul>
+            </nav>
+            <h1>
+                <abbr lang="fr" title="Référentiel Général d'Accessibilité des Administrations">RGAA</abbr> 3.0 - Glossary - English translation
+            </h1>
+            <p>The RGAA is the French government's General Accessibility Reference for Administrations. It is meant to provide a way to check compliance against <abbr title="Web Content Accessibility Guidelines, version 2.0">WCAG 2.0</abbr>.</p>
+            <p>
+                This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
+            </p>
+            <p>
+                The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
+            <p>
+                Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
+            </p>
+            <p>
+                Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
+            </p>
+            <h2 id="toc">
+                Table of Contents
+            </h2>
+            <nav role="navigation" aria-labelledby="toc">
+                <ul>
+                    <li><a href="#a">A</a></li>
+                    <li><a href="#b">B</a></li>
+                    <li><a href="#c">C</a></li>
+                    <li><a href="#d">D</a></li>
+                    <li><a href="#e">E</a></li>
+                    <li><a href="#f">F</a></li>
+                    <li><a href="#h">H</a></li>
+                    <li><a href="#i">I</a></li>
+                    <li><a href="#l">L</a></li>
+                    <li><a href="#m">M</a></li>
+                    <li><a href="#n">N</a></li>
+                    <li><a href="#o">O</a></li>
+                    <li><a href="#p">P</a></li>
+                    <li><a href="#r">R</a></li>
+                    <li><a href="#s">S</a></li>
+                    <li><a href="#t">T</a></li>
+                    <li><a href="#u">U</a></li>
+                    <li><a href="#v">V</a></li>
+                    <li><a href="#w">W</a></li>
+                </ul>
+            </nav>
+        </header>
+        <main role="main">
+
+            <p class="navTheme"><a href="#b">Skip to B</a></p>
+            <h2 id="a">A</h2>
+            <h3 id="mAccColl">Access to each page (of the collection of pages)</h3>
+            <p>
+                In the cases where the collection contains a large number of pages, it is usual to provide only links to one page in ten, for instance. This practice passes the test.
+            </p>
+            <h3 id="mAAClavierSouris">Accessible and activable by keyboard and mouse</h3>
+            <ul>
+                <li> A user interface component (link, button, clickable element in a Flash movie&hellip;) is accessible by keyboard and mouse when it can receive  focus, indifferently, through the use of the mouse pointer or the Tab key.
+                </li>
+                <li>A user interface component (link, button, clickable element in Flash&hellip;) can be activated with keyboard and mouse when the user can initiate the action triggered by the user interface component indifferently with a mouse click or the Enter key.</li>
+                <li>
+                    <strong>Warning</strong>: for some user interface components such as sliders (sliding or rotating button&hellip;), it is not possible to control the component only with the Enter key. In this situation, other keys (such as the arrow keys) can be used.
+                </li>
+            </ul>
+            <p>
+                <strong>Important notice:</strong> Some technologies can make focus management too complex or unstable to rely only upon the Tab, arrow and Enter keys.
+            </p>
+            <p>In this case, keyboard shortcuts may be the only solution to make the composant usable.</p>
+            <p>The criterion can be considered as Compliant, if the keyboard shortcuts are appropriately documented, and operable for every location of the focus in the user interface.</p>
+            <p>The following WCAG Technique:  <a href="http://www.w3.org/WAI/GL/WCAG20-TECHS/SL15.html">SL15: Providing Keyboard Shortcuts that Work Across the Entire Silverlight Application</a> provides information on this matter, for the Silverlight technology. </p>
+
+            <h3 id="mVaccessible">Accessible version (of a downloadable document)</h3>
+
+            <p>Downloadable documents provided in format types that are accessibility-supported must be accessible, or an alternate accessible version, or an accessible HTML version, must be provided. The document formats considered as  accessibility-supported are:</p>
+            <ul>
+                <li>Microsoft Office (Word 2003 and later, OOXML)</li>
+                <li>   Open Office Org (ODF)</li>
+                <li>    Adobe PDF</li>
+                <li>    Epub/Daisy</li>
+            </ul>
+            <p>Contents must conform to the <a href="http://references.modernisation.gouv.fr/sites/default/files/liste-criteres-documents-bureautiques-telechargement-RGAA.odt">list of criteria for downloadable electronic documents (ODT, 56 kb, in French)</a>.</p>
+            <p>
+                <strong>Note:</strong>The txt format cannot be used to provide an accessible version of a downloadable document.
+            </p>
+            <h3 id="mAdaptsARIADP">Adapts a design pattern defined by the ARIA API</h3>
+            <p>The ARIA API defines design patterns, for tab lists or modal windows for example, designed to provide a standardized behavior for user interface components. The application of these design patterns is required by the RGAA.</p>
+            <p>However, it is possible to adapt these design patterns, by replacing a poorly supported property by an equivalent one, or by enriching the component with properties that improve the user experience, or secure the component's behaviour.</p>
+            <p>It is the author's responsibility to check that these adaptations are consistent with the design pattern; that they do not modify the expected behavior, from a user experience point of view; and that the adapted component is correctly rendered by assistive technologies.</p>
+            <p>If these requirements are met, the component can be declared "compliant" with the design pattern.</p>
+            <h3 id="mLienAdj">Adjacent link</h3>
+            <p>Link adjacent to an element both in the layout (CSS enabled) and in the HTML code. In the HTML code, the link must be just before or after the element it is adjacent to.</p>
+            <h3 id="mAlerte">Alert</h3>
+            <p>Alert message that interrupts navigation or consultation, requiring the user to click on a button or a link in order to proceed; for example, a dialog box generated via the <code>alert</code> JavaScript function. By extension, a pop-in (content presented in an overlay, is inserted in the DOM) that needs to be closed to proceed, is considered as an alert.</p>
+            <p>
+                <strong>Note:</strong> An option may be proposed  to disable the alerts before they are triggered, for example, via a user parameter. Other example:  when the first alert is displayed, a checkbox "do not display this alert anymore" can be ticked by the user. </p>
+
+            <h3 id="mMecaRempl">Alternate mechanism</h3>
+            <p>
+                Mechanism (CSS-based, generally), allowing the user to replace text with an image of text, and reversely, like a style switcher for instance. The mechanism can rely either on a server-side or client-side script language.
+            </p>
+            <h3 id="mAltCC">Alternative (short and concise)</h3>
+            <p>
+                Rendering a text alternative via an assistive technology (like a screen magnifier for instance), requires that it should be as short as possible. A length of 80 characters is strongly recommended; it will reduce the manipulations to read the text alternative for users of Braille displays or screen magnifiers, in particular.
+            </p>
+            <h3 id="mAltTexteImg">Alternative (Text alternative of an image)</h3>
+            <p>
+                A text asssociated to an image via an appropriate technique, describing the information conveyed by the image (in relation with the context of the Web content it is included in). RGAA considers four types of alternatives, depending on the purpose of the image:</p>
+            <ul>
+                <li>
+                    <strong>For an image that conveys information</strong>, the text alternative provides the information needed to understand the content the image is associated with;
+                </li>
+                <li>
+                    <strong>For a decorative image</strong>, the alternative must be empty (<code>alt=""</code>);
+                </li>
+                <li>
+                    <strong>For an image link</strong>, the text alternative describes the purpose or the target of the link;
+                </li>
+                <li>
+                    <strong>For a CAPTCHA or test image</strong>, the text alternative can not provide the information conveyed by the image without compromising  the associated security function. In this case, the alternative should only describe the nature and purpose of the image.
+                </li>
+            </ul>
+            <p><strong>Note 1:</strong> for a CAPTCHA image, the text alternative can be, for instance: "anti-spam security code", or "code to check you are human", or any other text providing the user with the ability to understand the nature and purpose of the image.
+            </p>
+            <p>
+                <strong>Note 2:</strong>Groups of non-linked images may constitute a particular case, when they provide an information as a group rather than as a single image. For example: several images of a star graphically describe the average result in an online voting system. In such cases, it is strongly recommended to provide a text alternative for the first image, that describes the purpose of the group, while the other images will be considered as decorative. On this subject, you may read this technical note: <a href="http://www.w3.org/TR/html-alt-techniques/#a-group-of-images-that-form-a-single-larger-picture-with-no-links-1">1.10 A group of images that form a single larger picture with no links</a>.
+            </p>
+            <h3 id="mAltScript">Alternative (to a script)</h3>
+            <p>
+                Text or process associated with the script, via an appropriate technique, and providing a function or a content similar to the one provided by the script.</p>
+            <p><strong>Note:</strong>
+                when an alternative to a JavaScript functionality is available, the website must provide the way to access it. It can be a link or a button providing access to an alternative page not relying upon JavaScript, or allowing to replace the component by an alternative component that does not rely on JavaScript, for instance.
+            </p>
+
+            <h3 id="mAudioOnly">
+                Alternative audio-only version
+            </h3>
+            <p>An audio-only version is an audio-based version of a content (in a form of a downloadable MP3 file for instance), provided as an alternative to video-only (video document with no audio information). The only impacted users, with video-only content, being users with visual impairments, WCAG considers as acceptable to provide an audio-only version.</p>
+            <p>The audio-only version must include all the useful visual information found in the video.</p>
+            <p>It is generally simpler to produce an audio version than a textual one when the video is very descriptive (the transcription requiring then a heavy workload in terms of copywriting). Authors are reminded, though, that only text transcripts provide a universal access to the information provided by the video. Indeed, video incurs potentially other barriers, like for users who do not have to ability to play the audio or video content.</p>
+
+            <h3 id="mAmbigueTtMonde">Ambiguous for everybody</h3>
+
+            <p>
+                the purpose cannot be determined from the link and all information of the Web page presented to the user simultaneously with the link (i.e., readers without disabilities would not know what a link would do until they activated it)
+            </p>
+            <p>
+                Example: The word guava in the following sentence "One of the notable exports is guava" is a link. The link could lead to a definition of guava, a chart listing the quantity of guava exported or a photograph of people harvesting guava. Until the link is activated, all readers are unsure and the person with a disability is not at any disadvantage.
+            </p>
+            <h3 id="mAncreNom">Anchor</h3>
+
+            <p>
+                In HTML, an anchor (also called bookmark) is composed of an <code>&lt;a&gt;</code>  tag with the <code>id</code> attribute and with no <code>href</code>; for example: <code>&lt;a id="content"&gt;&lt;/a&gt;</code>.
+                An anchor serves as a target for a link like  <code>&lt;a href="index.html#content"&gt;skip to content&lt;/a&gt;</code>.
+            </p>
+            <h3 id="mZone">Area (of an image map)</h3>
+            <p>Clickable or non clickable area of an image map.</p>
+            <h3 id="mZoneCliquable">Area (Clickable)</h3>
+            <p>
+                Image map with an attached behavior; for example, triggering an event by clicking on a link (for a client-side clickable area: <code>area</code> tag with a <code>href</code> attribute). The <code>area</code> tags are descendants of a <code>map</code> tag.
+            </p>
+            <p>With server-side image maps, the coordinates are stored on the server.</p>
+            <h3 id="mZoneNonCliquable">Area (Non clickable)</h3>
+            <p>
+                Image map with no attached behavior (for a client-side area: <code>area</code> tag with no <code>href</code> attribute). The <code>area</code> tags are descendants of a <code>map</code> tag.
+            </p>
+            <h3 id="mZoneTexte">Area (Text)</h3>
+            <p>
+                Image map region containing text.
+            </p>
+
+
+            <h3 id="mAudioDescE">Audio description (Extended)</h3>
+            <p>Audio description that is added to an audiovisual presentation by pausing the video so that there is time to add additional description.</p>
+
+            <p>
+                <strong>Note:</strong> This technique is only used when the sense of the video would be lost without the additional audio description and the pauses between dialogue/narration are too short.
+            </p>
+
+
+            <h3 id="mAudioDesc">Audio description (Synchronized, time-based media)</h3>
+            <p>
+                Narration added to the soundtrack to describe important visual details that cannot be understood from the main soundtrack alone. The audio description must be synchronized with the time-based media</p>
+
+            <p>
+                <strong>Note 1:</strong> Audio description of video provides information about actions, characters, scene changes, on-screen text, and other visual content.
+            </p>
+            <p>
+                <strong>Note 2:</strong> In standard audio description, narration is added during existing pauses in dialogue. (See also extended audio description.)
+            <p><strong>Note 3:</strong> Where all of the video information is already provided in existing audio, no additional audio description is necessary.</p>
+
+            <h3 id="mRedirectAuto">Automatic redirection</h3>
+            <p>
+                Process consisting in automatically redirecting the user from a page to another, on the same domain or a different domain.</p>
+
+
+            <ul class="navTheme">
+                <li><a href="#a">Skip to A</a></li>
+                <li><a href="#c">Skip to C</a></li>
+            </ul>
+            <h2 id="b">B</h2>
+            <h3 id="mBtnForm">Button (form)</h3>
+            <p>A form element designed to perform a predefined action when activated. For instance, a submit button, when pressed, initiates the transmission of the data collected from the form to the web server. The button text must describe the action resulting in its activation (for example: "Start search", "Send your message").
+            </p>
+            <p>
+                In HTML, there are three types of button elements:</p>
+            <ul>
+                <li><code>INPUT</code> of type <code>submit</code>, <code>reset</code> or <code>button</code>,</li>
+                <li><code>INPUT</code> of type <code>image</code>,</li>
+                <li><code>BUTTON</code>.</li>
+            </ul>
+            <p>
+                There can be four types of button text:</p>
+            <ul>
+                <li>the content of the <code>value</code> attribute, for buttons of type <code>submit</code>, <code>reset</code> or <code>button</code>,</li>
+                <li>the content of the <code>alt</code> attribute for a button of type <code>image</code>,</li>
+                <li>the content of the <code>title</code> attribute when it is defined,</li>
+                <li>the content of the <code>button</code> tag.</li>
+            </ul>
+
+            <h3 id="mLienEvitement">
+                Bypass or skip links
+            </h3>
+
+            <p>Links whose purpose is to navigate inside of content (skip link, link to  the search form or the menu).</p>
+
+            <ul class="navTheme">
+                <li><a href="#b">Skip to B</a></li>
+                <li><a href="#d">Skip to D</a></li>
+            </ul>
+            <h2 id="c">C</h2>
+            <h3 id="mcaptcha">
+                CAPTCHA
+            </h3>
+            <p>
+                A CAPTCHA is a test designed to tell computers and humans apart. The test is often based on images containing distorted text, mixed with other shapes, or with altered colors. The user is requested to key in the obscured characters. Other forms of CAPTCHA can be based on logical questions or audio clips.
+            </p>
+            <h3 id="mChangContexte">
+                Change of context
+            </h3>
+
+            <p>Major changes in the content of the Web page that, if made without user awareness, can disorient users who are not able to view the entire page simultaneously. Changes in context include changes of:</p>
+
+            <ol>
+                <li>user agent</li>
+                <li>viewport</li>
+                <li>focus</li>
+                <li>content that changes the meaning of the Web page</li>
+            </ol>
+
+            <p><strong>Note:</strong> A change of content is not always a change of context. Changes in content, such as an expanding outline, dynamic menu, or a tab control do not necessarily change the context, unless they also change one of the elements listed above (e.g., focus).</p>
+
+            <p><strong>Example:</strong> Opening a new window, moving focus to a different component, going to a new page (including anything that would seem to to users as if they had moved to a new page) or significantly re-arranging the content of a page, are examples of changes of context.</p>
+
+            <h3 id="mChangeNativeRole">
+                Change of native role of an HTML element
+            </h3>
+            <p>The WAI-ARIA specification allows to modify the native role of an element, like for instance changing an <code>A</code> element (with an href attribute) into a <code>BUTTON</code> element.
+            </p>
+            <p>These modifications can be made only under certain conditions, described in the document <a href="https://www.w3.org/TR/aria-in-html/">Notes on Using WAI-ARIA in HTML</a>, which defines several restrictions, in particular.
+            </p>
+            <p>To be considered conformant, a change of the native role of an HTML element via WAI-ARIA must comply with these restrictions.
+            </p>
+
+            <h3 id="mChangeLumi">
+                Changes in luminosity (sudden) or flashing effects
+            </h3>
+            <p>A rapid alternance of colors with very different levels of luminosity, that can cause seizures in some people, if the flashing area is large enough, and the rate of change within specific frequency ranges.
+            </p>
+
+
+
+            <h3 id="mTailleCaractere">
+                Character size
+            </h3>
+            Size of the characters of textual content found in the page. In order to be accessible, font sizes must be defined with relative units (<code>%</code>, <code>em</code> or <code>rem</code>) or keywords (<code>xx-small</code>, <code>x-small</code>, <code>small</code>, <code>medium</code>, <code>large</code>, <code>x-large</code>, <code>xx-large</code>, <code>smaller</code>, or <code>larger</code>).
+            <p><code>Note:</code> with regards to the RGAA, the use of the pixel unit (<code>px</code>) is prohibitted.</p>
+
+            <h3 id="mCollecPage">
+                Collection of pages
+            </h3>
+            <p>
+                Pages linked to each other via hyperlinks, and with a common subject or nature. For example, the result pages of a search engine or the pages of a catalogue are collections of pages.</p>
+
+            <h3 id="mCoherentODL">
+                Consistent (reading or tabbing order)
+            </h3>
+
+            <p>Consistent content is readable (the elements order is logical) and understandable (the reading logic is consistent).
+            </p>
+
+
+            <h3 id="mContraste">
+                Contrast (color)
+            </h3>
+
+            <p>Significant opposition between a foreground color and a background color. The contrast ratio is based on the difference of relative luminance between background and foreground according to the rule: (L1 + 0.05) / (L2 +0.05) where L1 is the relative luminance of the lighter color, and L2 is the relative luminance of the darker  color. The luminance is calculated according to the following formula: L = 0,2126 * R + 0,7152 * G + 0,0722 * B where R, G and B are defined as:
+            <ul>
+                <li>if RsRGB >= 0,03928 then R = RsRGB/12,92 else R = ((RsRGB+0,055)/1,055) ^ 2,4</li>
+                <li> if GsRGB >= 0,03928 then --G = GsRGB/12,92 else G = ((GsRGB+0,055)/1,055) ^ 2,4</li>
+                <li>if BsRGB >= 0,03928 then B = BsRGB/12.92 else B = ((BsRGB+0,055)/1,055) ^ 2,4</li>
+            </ul>
+            <p> and RsRGB, GsRGB, and BsRGB are defined as:</p>
+
+            <ul>
+                <li>RsRGB = R8bit/255</li><li> GsRGB = G8bit/255</li><li> BsRGB = B8bit/255</li>
+            </ul>
+
+
+            <p> The "^" character is the exponentiation operator.</p>
+
+            <p><strong>Note:</strong> The contrast measurment is related to the text, the image of text, text and images of text in animations, the text in captions, and text that is embedded in videos. As far as text and images of text of animations and the text in captions and embedded text in videos are concerned, the font size must be measured according to the default displaying size, (as displayed). Text that is avaailable in the elements of an image or a video (for example a sign, a poster etc.) are not concerned.</p>
+
+
+            <h3 id="mControlSound">
+                Control (of autoplaying sound)
+            </h3>
+
+            <p>Ability for the user to pause and play an autoplaying sound.
+            </p>
+            <p><strong>Note:</strong> when appropriate, the controlling device should be the first element in the page.</p>
+
+            <h3 id="mFonctionControle">
+                Control features (time-based media)
+            </h3>
+            <p>Functionalities enabling the user to control the playing of a time-based media, with the keyboard or the mouse, at least. The following requirements must be met:
+            </p>
+            <ul>
+                <li>List of required control features:
+                    <ul>
+                        <li>the time-based media must always have at least the following features: play, pause, stop ;
+                        </li>
+                        <li>if the time-based media has sound, it must have a feature to set the sound on and off, and to control the volume;
+                        </li>
+                        <li>if the time-based media has captions, it must have a feature enabling to display and hide  captions;
+                        </li>
+                        <li>if the time-based media has an audio description, it must have a feature enabling to activate and disactivate the  audio description.
+                        </li>
+                    </ul>
+                </li>
+                <li>Each functionality mus be accessible with the keyboard, via the Tab key, and the mouse, at least;</li>
+                <li>Each functionality must be actionable with the keyboard or the mouse, at least.</li>
+            </ul>
+
+            <p><strong>Note:</strong> If a multimedia object has no sound, there is no need for a feature to control its volume.
+            </p>
+
+
+            <h3 id="mControleMov">
+                Control (moving or blinking content)
+            </h3>
+
+            <p>Ability for the user to control the display or reading of moving or blinking content at least with the keyboard and the mouse.
+            </p>
+            <p>Every content in motion, except time-based media ruled by the "Multimedia" criteria category, are concerned: animated images (like animated GIFs), content in motion served via an <code>object</code> tag, JavaScript code, or CSS effects, for example.
+            </p>
+            <p><strong>Note 1:</strong> when appropriate, the controlling device should be the first element in the page.</p>
+            <p><strong>Note 2:</strong> the controlling device must not prevent the user from interacting with the rest of the page. Consequently, stopping or pausing a content in motion via an event triggered on focus, fails this criterion.</p>
+            <p><strong>Note 3:</strong> in some cases, the motion is part of the component, and it can not be controlled by the user. Example: a progress bar indicating by its movement the progress of an event like a download. In this case, the criterion is not applicable.</p>
+
+            <h3 id="mControleClavSour">
+                Controllable by keyboard and mouse
+            </h3>
+
+            <p>Controlling a functionality with the keyboard means that it can be accessed via the Tab key and activated via the Enter key, except for:
+            </p>
+            <ul>
+                <li>User interface components implementing WAI-ARIA, when a <a href="./RGAA3.0_Glossary_English_version_v1.html#mDesignPAttern">Design Pattern</a> defines requirements for specific  keyboard interactions;
+                </li>
+                <li>When a component makes use of a technology that requires keyboard shortcuts, and the Tab key is not available.</li>
+            </ul>
+
+            <h3 id="mEnvMait">
+                Controlled environment
+            </h3>
+
+            <p>Any environment in which access to information, technologies, terms of use and users profiles can be known and controlled. The main elements for which control is essential are:
+            </p>
+            <ul>
+                <li>The browsers types and versions
+                </li>
+                <li>The supported technologies, their versions and activation statuses (JavaScript, WAI-ARIA, Flash&hellip;)
+                </li>
+                <li>The assistive technologies and any device used in a specific way by users with disabilities
+                </li>
+                <li>The operating systems and accessibility APIs
+                </li>
+                <li>The level of proficiency of users of assistive technologies, for any specific device (user interface, online application&hellip;) in use in this environment.
+                </li>
+
+            </ul>
+            <p>Authors and administrators must guarantee that the technologies in use, and the way they are utilized by users, are compatible with their technologies (including assistive technologies). Information services or Web sites, whatever their status, that provide public access cannot be considered as controlled environments.</p>
+
+            <h3 id="mCorrectlyRendered">
+                Correctly rendered (by assistive technologies)
+            </h3>
+            When a criterion, a test or a test condition requires to verify that a device is correctly rendered by assistive technologies, it must be checked that this rendering is accessibility supported.
+            The test consists in checking that the rendering is relevant for at least one combination of the <a href="./RGAA3.0_Baseline_English_version_v1.html">Reference baseline</a> used to declare that an element, a device or an alternative is "accessibility supported".
+            For example: Test 1.3.7 requires to check that the alternative of a vector image conveying information is correctly rendered.
+            The rendering is then tested with NVDA (last version) and Firefox, JAWS (previous version) and Internet Explorer 9+, and VoiceOver (last version) and Safari.
+            If the alternative is correctly rendered, then the test is passed.
+
+
+            <h3 id="mPropCouleur">
+                CSS property defining a color
+            </h3>
+
+            <p>This concerns the following CSS properties: <code>color</code>, <code>background>-color</code>, <code>background</code>, <code>border-color</code>, <code>border</code>, <code>outline-color</code>, <code>outline</code>.
+            </p>
+            <p> <strong>Note:</strong> the use of a background image to set a color (<code>bakground:url(&hellip;)</code> property) is also concerned.
+            </p>
+
+            <ul class="navTheme">
+                <li><a href="#c">Skip to C</a></li>
+                <li><a href="#e">Skip to E</a></li>
+            </ul>
+
+            <h2 id="d">D</h2>
+
+            <h3 id="mTypeDonnes">
+                Data type and format
+            </h3>
+
+            <p>Indication regarding expected data type and format when information is entered in a form field. For example:
+            </p>
+            <ul>
+                <li>date (yyyy/mm/dd)</li>
+                <li>Total in euros</li>
+                <li>Zip code (5 numbers: eg. 75001)</li>
+
+            </ul>
+            <p><strong>Important note</strong>: when the type of the form field involves an input mask, like for instance fields of types <code>date</code> or <code>time</code>, the indication of expected format is not required.</p>
+
+
+            <h3 id="mLangueDefaut">
+                Default human language
+            </h3>
+
+            <p>Language specification used by the user-agent (including assistive tchnologies) to apply language-specific  rules when rendering content. The language code is provided via the <code>lang</code> and/or <code>xml:lang</code> attributes, defined for the <code>html</code> tag (container for the whole document in the web page), or every descendant tag with content to which these rules should apply. The choice of attributes depends on the Document Type Definition (DTD) used:
+            </p>
+            <ul>
+                <li>For HTML up to version 4.01:  <code>lang</code> attribute mandatory, <code>xml:lang</code> attribute not supported;
+                </li>
+                <li>For XHTML 1.0 served in "text/html": <code>lang</code> and <code>xml:lang</code> attributes mandatory;
+                </li>
+                <li>For XHTML 1.0 served in "application/xhtml+xml": <code>xml:lang</code> attribute mandatory, <code>lang</code> attribute recommended;
+                </li>
+                <li>For XHTML 1.1: <code>xml:lang</code> attribute mandatory, <code>lang</code> attribute not supported;</li>
+                <li>For HTML5: <code>lang</code> attribute mandatory.</li>
+
+            </ul>
+
+
+            <h3 id="#mDesignPattern">
+                Design Pattern
+            </h3>
+            <p>A design pattern is a model defined by the ARIA API describing the structure, roles, properties and behaviors a JavaScript component (widget) must have.</p>
+            <p>The design patterns are described in this document: <a href="http://www.w3.org/WAI/PF/aria-practices/">WAI-ARIA 1.0 Authoring PRactices</a>.
+            </p>
+            <p>A JavaScript-based component must follow the design pattern corresponding with its WAI-ARIA role.
+            </p>
+
+            <p><strong>Note 1</strong>: because some WAI-ARIA properties and roles are not supported by all user agents, and because of the wide variety of situations where a JavaScript component can be used, it is allowed to adapt design patterns to specific contexts or uses. In this case, the adapted design pattern must:
+            </p>
+            <ul>
+
+                <li>respect the general structure; for instance, a tab panel is necessarily associated with a tab list;
+                </li>
+                <li>in place of a WAI-ARIA role or property with poor support, equivalent WAI-ARIA roles or properties may be used as long as they display similar behavior and rendering by user agents
+                </li>
+            </ul>
+            <p><strong>Note 2:</strong> this does not apply to enrichments of a design pattern with WAI-ARIA roles or properties, for which accessibility support is verified through rendering tests with the reference baseline. For example, adding the <code>aria-hidden</code> property on tab panels (<code>role="tabpanel"</code>) is not considered as an adapted design pattern.
+            </p>
+
+            <h3 id="mDescDetaillee">
+                Detailed description (image)
+            </h3>
+
+            <p>Content related to an image in addition to its text alternative, in order to fully describe information conveyed by the image. The detailed description can be inserted via:</p>
+
+            <ul>
+                <li>a <code>longdesc</code> attribute containing the URL of a page, or of a content in the same page, containing the detailed description,
+                </li>
+                <li>a reference, in the <code>alt</code> attribute, to a detailed description adjacent to the image,
+                </li>
+                <li>A link adjacent to the image, to a page or a content in the same page, containing the detailed description,
+                </li>
+                <li>A chunk of text, associated to the image by means of aria-labelledby or aria-describedby properties.</li>
+
+            </ul>
+
+
+            <h3 id="mDocumentOutline">Document outline</h3>
+            <p>
+                The Test 9.2.2 requires that the structure of the sectioning elements (<code>NAV</code>), <code>SECTION</code>, <code>ARTICLE</code> for instance) in the page is coherent; meaning it's representative of the document's architecture. This structure is completed by the headings (<code>h1</code> to <code>h6</code> tags) structure, which is also a part of it.
+            </p>
+            <p>Inappropriate use of these sectioning elements could result in an incoherent document outline, through excessive use of <code>SECTION</code> or <code>ARTICLE</code> elements for example.</p>
+            <p><strong>Note 1:</strong>The document outline algorithm is progressively supported by browsers and assistive technologies. Considering that, in any case, the RGAA requires a robust and coherent headings hierarchy, <strong>it is acceptable to consider the Test 9.2.2 as not applicable</strong> when a perfectly coherent document outline can not be guaranteed. You may read this technical note: <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit9-2">Technical note on document outline</a>.</p>
+            <p><strong>Note 2</strong>You may read, on the same subject, the example provided in the HTML5 specification: <a href="http://www.w3.org/TR/html5/sections.html#sample-outlines">4.3.10.2 Sample outlines</a>.
+            </p>
+
+            <h3 id="mDTD">
+                Document type
+            </h3>
+
+            <p>Set of reference data allowing user agents to know the technical characteristics of the languages used in the page (<code>doctype</code> tag).
+            </p>
+
+            <ul class="navTheme">
+                <li><a href="#d">Skip to D</a></li>
+                <li><a href="#f">Skip to F</a></li>
+            </ul>
+            <h2 id="e">E</h2>
+            <!--
+            <h3 id="mEquivalentRole">
+            Equivalent WAI-ARIA role
+            </h3>
+            -->
+
+            <h3 id="mExpliciteHorsContexte">
+                Explicit out of context (link)
+            </h3>
+
+            <p>A link is explicit out of its context when the link text (content between <code>&lt;a href=""&gt;</code> and <code>&lt;/a&gt;</code>) provides enough information to understand the function and purpose of the link.</p>
+
+            <ul class="navTheme">
+                <li><a href="#e">Skip to E</a></li>
+                <li><a href="#g">Skip to G</a></li>
+            </ul>
+            <h2 id="f">F</h2>
+
+            <h3 id="mPriseFocus">
+                Focus
+            </h3>
+
+            <p>Focus is the state sent by an element that receives attention after a user action. In HTML there are three means to give focus to an element:
+            </p>
+            <ul>
+
+                <li>Activating the element with a pointing device (mouse)</li>
+                <li>Activating the element with the Tab key</li>
+                <li>Activating the element with a keyboard shortcut (<code>accesskey</code>)</li>
+
+            </ul>
+            <p>Elements that receive focus natively are: <code>a</code>, <code>area</code>, <code>button</code>, <code>input</code>, <code>object</code>, <code>select</code>, <code>label</code>, <code>legend</code>, <code>optgroup</code>, <code>option</code> and <code>textarea</code>. The element's behaviour, when it is focused, depends on its nature; a link, for example, must be activated afted it has been focused (except when a script is used). On the other hand, a form element, such as <code>textarea</code>, must allow input after it has received focus. The <code>label</code> and <code>legend</code> elements can only receive focus via the mouse pointer. For the <code>label</code> element, the expected behavior is to transfer focus to the form field it is associated with.
+            </p>
+            <p><strong>Note 1:</strong> The WAI-ARIA specification extends the role assigned to the <code>tabindex</code> attribute, by defining that any HTML element can become focusable by setting <code>tabindex</code> at 0. However, no behavior is defined if <code>tabindex</code> is declared but has no set value. Setting an element's <code>tabindex</code> at -1 (minus one) removes this element from the tabbing order, inhibiting its ability to signal it has gained focus. Using <code>tabindex</code> accordingly with the WAI-ARIA specification can validate some tests related to focus management.
+            </p>
+            <p><strong>Note 2:</strong> the focus visual cue must not be degraded, meaning that its visibility is lessened compared to the user agent's default style.
+            </p>
+
+            <h3 id="mFooter">
+                Footer
+            </h3>
+            <p>
+                Container of information related to the use of the site, or legal information. This is generally where can be found links to the help page, the credits page, terms of use, and the accessibility page, potentially.
+            </p>
+
+            <p><strong>Note:</strong> this page footer area, unique in a page, must not be mistaken with footers of sections, defined in HTML5 with the <code>footer</code> tag.
+            </p>
+            <p>See the technical definition as defined by the ARIA API: <a href="https://www.w3.org/WAI/PF/aria/roles#contentinfo">Contentinfo (role)</a>.
+
+            <h3 id="mEtiquette">
+                Form field label
+            </h3>
+
+            <p>Text located next to the form field describing the nature, type or format of expected input. The label can be associated with the form field in several ways: with a <code>label</code> tag, an <code>aria-label</code> property, an <code>aria-labelledby</code> property and its related text, a <code>title</code> attribute.
+            </p>
+            <h3 id="mChpSaisie">
+                Form input field
+            </h3>
+            <p>
+                Object, in a form, allowing the user:</p>
+            <ul>
+                <li>to enter text or pre-formatted data:
+                    <ul>
+                        <li><code>input type="text"</code>;</li>
+                        <li><code>input type="password"</code>;</li>
+                        <li><code>input type="search"</code>;</li>
+                        <li><code>input type="tel"</code>;</li>
+                        <li><code>input type="email"</code>;</li>
+                        <li><code>input type="number"</code>;</li>
+                        <li><code>input type="tel"</code>;</li>
+                        <li><code>input type="url"</code>;</li>
+                        <li><code>textarea</code>;</li>
+                    </ul>
+                </li>
+                <li>to select predefined values:
+                    <ul>
+                        <li><code>input type="checkbox"</code></li>
+                        <li><code>input type="radio"</code></li>
+                        <li><code>input type="date"</code></li>
+                        <li><code>input type="range"</code></li>
+                        <li><code>input type="color"</code></li>
+                        <li><code>input type="time"</code></li>
+                        <li><code>select</code></li>
+                        <li><code>datalist</code></li>
+                        <li><code>optgroup</code></li>
+                        <li><code>option</code></li>
+                        <li><code>keygen</code></li>
+                    </ul>
+                </li>
+                <li>to download files:
+                    <ul>
+                        <li><code>input type="file"</code></li>
+                    </ul>
+                </li>
+                <li>or to display results:
+                    <ul>
+                        <li><code>output</code></li>
+                        <li><code>progress</code></li>
+                        <li><code>meter</code></li>
+                    </ul>
+                </li>
+            </ul>
+            <p>The following form objects are not considered as form fields:</p>
+
+            <ul>
+                <li><code>input type="submit"</code></li>
+                <li><code>input type="reset"</code></li>
+                <li><code>input type="hidden"</code></li>
+                <li><code>input type="image"</code></li>
+                <li><code>input type="button"</code></li>
+                <li><code>button</code></li>
+            </ul>
+
+            <h3 id="mTitreCadre">
+                Frame title
+            </h3>
+
+            <p>Value of the <code>title</code> attribute of the  <code>iframe</code> tag, describing the nature of the content provided via the inline frame, useful when navigationg from frame to frame, or displaying the list of frames in the page, for example.
+            </p>
+            <p><strong>Note 1:</strong> some inline frames only have a purely technical purpose, like preprocessing content displayed in the page (commonly found for social networks widgets like Facebook's, for instance).
+            </p>
+            <p>If the remote content inside the frame has no title, or if it is  not relevant, generic indications may be used, like for example: "Facebook: technical contents".</p>
+            <p><strong>Note 2:</strong> If there is no impact on the functionality, these contents may be hidden to assistive technologies, via the <code>aria-hidden</code> attribute, for instance.</p>
+
+            <ul class="navTheme">
+                <li><a href="#f">Skip to F</a></li>
+                <li><a href="#i">Skip to I</a></li>
+            </ul>
+            <h2 id="h">H</h2>
+            <h3 id="mCelluleTab">
+                Header cells (of a table)
+            </h3>
+            <p>
+                Cells of a data table (first cell in a row or a column, generally), serving as a title for all, or some of, the row or column other cells. A column or a row can have several headers (intermediary headers). Header cells must be coded with a <code>th</code> tag.
+            </p>
+
+            <h3 id="mTitre">
+                Heading
+            </h3>
+
+            <p>HTML element (h<i>n</i> tag) with 6 hierarchy levels (from <code>h1</code> for the most important heading to <code>h6</code> for the less important), allowing to define and title sections in a Web content. The hierarchy between headings must be respected on a Web page, and the heading levels cannot be skipped: a <code>h3</code> heading (level 3) cannot be the next heading after a <code>h1</code> heading (level 1), for example. On each Web page, there must be at least one <code>h1</code> heading.</p>
+
+            <p><strong>Note:</strong> Headings hidden via CSS are considered as available to the user, and validate criterion 9.1.
+            </p>
+            <h3 id="mTexteCache">
+                Hidden text
+            </h3>
+
+            <p>Assistive technologies (in particular, screen readers) do not render content hidden via these properties:
+            </p><ul>
+
+                <li>(CSS) <code>display:none</code>;</li>
+                <li>(CSS) <code>visibility:hidden</code></li>
+                <li>(CSS)<code>width=0; height=0;</code></li>
+                <li>(HTML) <code>width=0</code> and <code>height=0</code></li>
+                <li>(CSS) <code>font-size:0;</code></li>
+                <li>(CSS) <code>clip:0;</code></li>
+                <li>(HTML5) <code>hidden</code> attribute;</li>
+                <li>(HTML+ARIA) <code>aria-hidden=true</code></li>
+
+            </ul>
+            <p>All text content using one or more of these properties are scoped by the criterion 10.13.</p>
+
+            <ul class="navTheme">
+                <li><a href="#h">Skip to H</a></li>
+                <li><a href="#l">Skip to L</a></li>
+            </ul>
+            <h2 id="i">I</h2>
+
+
+
+            <h3 id="mImgDeco">
+                Image (decorative)
+            </h3>
+
+            <p>An image that has no purpose and that does not convey any particular information regarding the content it is associated with. Examples:
+            </p>
+            <ul>
+                <li>An image used for layout adjustments only,</li>
+                <li>an image of a rounded corner, used to style a block,</li>
+                <li>an illustrative image that does not provide any information that helps understanding the text it is associated with.
+                </li>
+
+            </ul>
+
+            <h3 id="mImgObj">
+                Image (object image)
+            </h3>
+            <p>
+                Image inserted or generated via an <code>object</code> tag.
+            </p>
+
+
+            <h3 id="mImgTextObj">
+                Image (object text image)
+            </h3>
+            <p>
+                Image implemented via the <code>object</code> tag and displaying text.
+            </p>
+
+            <h3 id="mImageCaption">
+                Image caption
+            </h3>
+            <p>For an image, a caption is an adjacent text, containing information about the image (for instance a copyright, a date, an author&hellip;), or information complementary to the one conveyed by the image (for instance, text associated with an image in a gallery).</p>
+            <p>When an image has a caption, it is necessary to tie the image and its caption together via a structure relationship, so that assistive technologies can process both as a whole.
+            </p>
+            <p>The HTML5 specification defines the <code>figure</code> (container for the image and its caption) and <code>figcaption</code> (container for the caption) tags.
+            </p>
+            <p>An image without caption can be:
+            </p>
+            <ul>
+                <li>an image that is not included in a <code>figure</code> element;</li>
+                <li>an image included in a <code>figure</code> element, with no <code>figcaption</code> element</li>
+
+            </ul>
+
+            <p>Note: when the text adjacent to the image can serve as its alternative text, it is not required to use <code>figure</code> and <code>figcaption</code> tags; the image can be considered as decorative in this situation.
+            </p>
+
+            <h3 id="mImgInfo">
+                Image conveying information
+            </h3>
+            <p>An image that conveys information needed to understand the content it is associated with.
+            </p>
+
+            <h3 id="mInfoDonneeCouleur">
+                Image conveying information (provided by color)
+            </h3>
+            <p>Image for which all or part of its content conveys information visually, by means of color only.
+            </p>
+
+            <h3 id="mLienImage">
+                Image link
+            </h3>
+            <p>
+                Link whose content between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> is only constituted of an image. The link text of an image link is the content of the  text alternative of the image.
+            </p>
+            <p><strong>Note:</strong> an image link may be based on an image (<code>img</code> tag), an object image (<code>object</code> tag) or a bitmap image (<code>canvas</code> tag).</p>
+
+            <h3 id="mImgReactive">
+                Image map
+            </h3>
+            <ol>
+                <li>    <strong>client-side image map</strong> (<code>usemap</code> attribute): image divided into clickable or non-clickable areas (<code>nohref</code> attribute).
+                </li>
+                <li>    <strong>Server-side image map</strong> (<code>ismap</code> attribute) : image for which the browser sends the coordinates of the pointing device to the server, each set of coordinates corresponding to a resource (URL). The server-side image map is extremely rare.
+                </li>
+            </ol>
+            <p>
+                Note: in HTML5, the <code>ismap</code> attribute is obsolete non conformant for form buttons of type image (<code>input type="image"</code>).
+            </p>
+
+            <h3 id="mImgText">
+                Image of text
+            </h3>
+            <p>
+                Image that displays text.
+            </p>
+
+            <h3 id="mInfoCouleur">
+                Information conveyed by color
+            </h3>
+
+            <p>Information that is visually conveyed by means of color. Indication that the required fileds of a form are in red; a change of background color to indicate the current page in a navigation menu; a change of text color to indicate that an article is unavailable, inside a list of articles; are all examples of information conveyed by color.</p>
+            <p>Information conveyed by color must be completed with another means of conveying information, that does not rely on visual perception, for users who do not perceive, or not well enough, colors and their combinations.</p>
+            <p>It is recommended to use additional text content, or images with appropriate text alternatives, to satisfy this requirement. Purely visual effects (change of style, size, boldness, typography, etc.) would not be considered sufficient, since they would not be perceived by users who do not have access to the graphical version of the page.</p>
+
+            <h3 id="mInfoShape">
+                Information conveyed by shape, size or location
+            </h3>
+
+            <p>It can be, for instance:</p>
+            <ul>
+                <li>a visual cue, to indicate the current page in a navigation menu (information conveyed by position),
+                </li>
+                <li>a visual effect to make the active tab in a tablist appear like it is in the foreground (information conveyed by shape);
+                </li>
+                <li>a change in text size in a tag cloud (information conveyed by size).
+                </li>
+            </ul>
+            <p>Or any other similar effect.</p>
+
+
+            <h3 id="mInfoMNature">Information of same nature</h3>
+            <p>
+                In a form, a set of fields that can be considered as a group because of the nature of the expected input.</p>
+            <p>Examples:</p>
+            <ul>
+                <li>Three consecutive fields to enter a date (year/month/day);</li>
+                <li>Consecutive fields for a phone number;</li>
+                <li>Fields for the name and address, when several similar blocks of input fields are available in the same form;</li>
+                <li>A set of radio buttons or checkboxes related to a question asked.</li>
+            </ul>
+            <p>These fields must be grouped together via a <code>fieldset</code> tag, and a relevant <code>legend</code> tag. In the case of radio buttons, generally, the legend is the question text.</p>
+            <p>
+                <strong>Note:</strong> When the form consists in only one block of input fields of same nature (user name and address, for example) or one single field (a search engine input field, for example), the <code>fieldset</code> tag is not required.</p>
+
+            <h3 id="mPresInfo">
+                Information presentation
+            </h3>
+
+            <p>Visual rendering of content via a graphic browser. Presentation concerns style, position and dimensions of HTML elements and their content. Information presentation must be performed with CSS. Are prohibited these elements: <code>basefont</code>, <code>blink</code>, <code>center</code>, <code>font</code>, <code>marquee</code>, <code>s</code>, <code>strike</code>, <code>tt</code>, <code>u</code>; and these attributes: <code>align</code>, <code>alink</code>, <code>background</code>, <code>basefont</code>, <code>bgcolor</code>, <code>border</code>, <code>color</code>, <code>link</code>, <code>text</code>, <code>vlink</code>. The <code>width</code> and <code>height</code> attributes used on other elements than images (<code>img</code> tag) are also prohibited. </p>
+
+            <h3 id="mCadreEnLigne">
+                Inline frame
+            </h3>
+            <p>
+                HTML element (<code>iframe</code> tag) providing a way to display contents from another page, inside the current web page.
+            </p>
+
+            <h3 id="mControleSaisie">
+                Input control (form)
+            </h3>
+
+            <p>All the processes designed to inform the user about required fields, expected types and formats, and  input errors in a form. These controls can be implemented by the content author, or rely upon HTML attributes (like <code>required</code> or <code>pattern</code>), WAI-ARIA properties (like <code>aria-required</code>) or field types automatically generating input indications or error messages (like <code>url</code>, <code>email</code>, <code>date</code>, <code>time</code>, for example).
+            </p>
+            <p>Important: after form submission with input errors, if an error handling page is displayed, the page title must include a mention like "input errors in the form".</p>
+
+
+            <ul class="navTheme">
+                <li><a href="#i">Skip to I</a></li>
+                <li><a href="#m">Skip to M</a></li>
+            </ul>
+            <h2 id="l">L</h2>
+            <h3 id="mLanguageChange">Language change</h3>
+            <p>An indication of language change tells user agents which language-specific rules should be applied to render appropriately parts of the content   written in a human language different from the main language of the content. This includes, notably, the vocal restitution performed by speech synthesizers. Language changes apply to all contents, including some attributes like <code>title</code>.</p>
+            <p><strong>Note:</strong> in HTML, it is not technically possible to signal language changes inside an attribute value. In this case, the language change is signalled via the element bearing this attribute. For instance, an hyperlink with a <code>title</code> attribute in German, in a page whose main language is English, should have a <code>lang</code> attribute set to <code>"de"</code>. When the attribute contains several language changes, the criterion is not applicable.
+            </p>
+
+            <h3 id="mCodeLangue">
+                Language code
+            </h3>
+
+            <p>Code with two characters (ISO 639-1) or 3 characters (ISO 639-2 and following) specifying the default language of a document or a chunk of text. The language code  is constituted of two parts separated by a dash on the model <code>lang="[code][-option]</code>".
+            </p>
+            <ul>
+                <li>[code] represents a valid language code of 2 or 3 characters;</li>
+                <li>[option] is an indication left to the author's judgment.</li>
+
+            </ul>
+            <p>When the [option]  is provided, it defines a language regionalisation. For example: <code>"en-us"</code> for American English. When checking for conformance against the RGAA, only the [code] part is evaluated.</p>
+
+
+            <h3 id="mLien">
+                Link
+            </h3>
+
+            <p>HTML element (<code>a</code> tag) that can be activated by the user (with the mouse, the keyboard&hellip;) and that initiates an action (generally, a page or file download) or an event generated by a script. A link has at least:
+            </p>
+            <ul>
+                <li>a resource reference (<code>href</code> attribute);</li>
+                <li>a link text between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>.</li>
+
+            </ul>
+            <h3 id="mLienComposite">
+                Link (Combined)
+            </h3>
+
+            <p>Link whose content between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> is formed with at least 2 elements of different types; for example, text and one or several images. The link text of a combined link is the whole text and the content of the text alternatives of the image(s)  between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>.
+            </p>
+            <p>Important notice: having two identical adjacent links (image and text links, for instance, with the same purposes, URL and link text) is a significant inconvenience for some users? Even though this is not a non-conformity, this practice should be avoided. A way to implement this kinfd of links is to include the image into the text link, in order to obtain a combined link.</p>
+
+            <p>On this subject, you may read this WCAG Technique: <a href="http://www.w3.org/TR/WCAG20-TECHS/H2.html">H2 : Combining adjacent image and text links for the same resource</a>.
+            </p>
+
+            <h3 id="mContexteLien">
+                Link context
+            </h3>
+
+            <p>The link context represents additional information that can be programmatically determined from relationships with a link, combined with the link text, and presented to users in different modalities. Programmatically determined contexts that can make a link explicit are the following:
+            </p>
+
+            <ul>
+                <li>The content of the sentence enclosing the link;</li>
+                <li>The content of the paragraph (<code>p</code> tag) containing the link;
+                </li>
+                <li>The content of the list item (<code>li</code> tag), or the content of a parent list item (<code>li</code> tag) of the list item,  containing the link;
+                </li>
+                <li>The content of the heading (<code>h1</code> to <code>h6</code> tags) that is the  closest ascendant of the link;
+                </li>
+                <li>The content of the table header cell(s) (<code>th</code> tags)  associated with the table data cell (<code>td</code> tag) containing the link;
+                </li>
+                <li>The content of the table data cell (<code>td</code> tag) containing the link;
+                </li>
+                <li>The content of the link title (<code>title</code> attribute);
+                </li>
+                <li>The content of the <code>aria-label</code> property;</li>
+                <li>The content of the chunk(s) of text associated with the link via the <code>aria-labelledby</code> property.</li>
+            </ul>
+            <p><code>Note 1:</code> One of the 9 link contexts alone must be sufficient to make the link explicit.</p>
+            <p><strong>Note 2:</strong> The RGAA considers that specific links like <code>mailto</code> links (interpreted by the user agent as a clickable e-mail address) are explicit by nature. therefore it is not required to inform the user, via a link title for instance, that the link triggers the opening of an e-mail client application. Authors are advised, however, to adapt this rule to the situation. For instance, if the page contains multiple clickable e-mail addresses, some opening thee-mail client application, other sending to a contact form, then it may be necessary to provide additional information in order to help the user understand the different uses of this type of links in this context.</p>
+
+            <h3 id="mLienIdentique">
+                Links (Identical)
+            </h3>
+
+            <p>Two links are considered identical when link x (link text only, content of the <code>title</code> attribute or link context) is equal to link y. This definition applies to all types of links: text links, image links (identical images) and combined links.</p>
+
+            <p><strong>Warning:</strong> links with identical texts but with different link titles or different link contexts are not identical. Example of non-identical links: <code>&lt;a href="link_bar.html" title="click here to download the toolbar"&gt;click here&lt;/a&gt;</code> and <code>&lt;a href="link_doc.html" title="click here to download the document"&gt;click here&lt;/a&gt;</code>).
+            </p>
+
+            <h3 id="mIntituleLien">
+                Link text
+            </h3>
+            <p>
+                Textual information contained between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> of a link completed if necessary with context information.</p>
+            <p> The four different types of links are:</p>
+            <ul>
+                <li>text link: text between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>, completed, if necessary, with context information;
+                </li>
+                <li>image link: text alternative(s) of the image(s) between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>, completed, if necessary, with context information;
+                </li>
+                <li>combined link: text, and text alternative(s) of the image(s) between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code>, completed, if necessary, with context information;
+                </li>
+                <li>vector link: text alternative of the vector image (<code>svg</code> tag) between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> completed, if necessary, with context information.
+                </li>
+            </ul>
+
+            <p><strong>Note 1:</strong> An image link can be based on an image (<code>img</code> tag), on image object (<code>object</code> tag) or a bitmap image (<code>canvas</code> tag).
+            </p>
+
+            <p><strong>Note 2:</strong> An image link with a missing <code>alt</code> attribute is considered as not applicable for criterion 6.5.
+            </p>
+
+            <h3 id="mTitreLien">
+                Link title
+            </h3>
+            <p>
+                Content of the <code>title</code> attribute of a link. This content must be set only if it is necessary to identify the link target in an explicit way. A link title must duplicate the link text, and add  complementary information. A link title will be considered as not relevant in the following situations:</p>
+
+            <ul>
+                <li>The link title is empty (<code>title=""</code>)</li>
+                <li>The link title is identical to the link text (see note 1)</li>
+                <li>The link title does not include the link text</li>
+
+            </ul>
+            <p><strong>Note 1:</strong> By exception, a link title identical to the link text is  tolerated in the case of an image link (a link that only contains images), like a clickable icon, for example.
+            </p>
+            <p>Authors are warned that relying upon the <code>title</code> attribute to convey information is unsafe. Specifically, contents in <code>title</code> attributes are not rendered visually when navigating with the keyboard, a tactile interface, or when an assistive technology user settings prevent them from being rendered. therefore, they should be used only as a last resort solution.</p>
+
+
+            <h3 id="mLienNature">
+                Link whose nature is not obvious
+            </h3>
+
+            <p>Link that can be confused with normal text, when it is indicated through color alone, by some types of users who have bad or no color perception. For example, in this text "New strike at SNCF", if the word "strike" is a link that is specified by color alone, its kind can be ignored by users who cannot perceive color and who access content with CSS enabled. On the other hand, in this text "New strike at SNCF, read more" if "read more" is a link, a user who does not perceive colors will have no difficulties to understand its nature.
+            </p><p>
+                <strong>Note:</strong> "indicated through color alone" means that the link is accompanied by no other visual indication (icon, underline, border&hellip;). As a consequence, a link of the same color as the surrounding text is targetted by this criterion.
+            </p>
+
+            <h3 id="mListes">
+                Lists
+            </h3>
+
+            <p>Sequence of elements that can be grouped in the form of a structured list as ordered, unordered or definition lists. For example, the  links in a navigation menu is an unordered list of links, the different steps in a process are an ordered list of items, the pair term/definition in a glossary is a definition list. In HTML, lists are defined using the following tags:
+            </p>
+            <ul>
+                <li>ordered list: <code>ol</code> and <code>li</code> tags (each list item is numbered incrementally)
+                </li>
+                <li>    unordered list: <code>ul</code> and <code>li</code> tags (each list item is, potentially, marked with a bullet point)
+                </li>
+                <li>    definition list: dl, dt: term(s) to be defined, and dd: definition data
+                </li>
+
+            </ul>
+
+            <ul class="navTheme">
+                <li><a href="#l">Skip to L</a></li>
+                <li><a href="#n">Skip to N</a></li>
+            </ul>
+            <h2 id="m">M</h2>
+            <h3 id="mMain">
+                Main content area
+            </h3>
+            <p>
+                Container of the main contents of the page, where can be found principal information and functionalities (therefore excluding menu, the search form, or secondary content blocks contaning related news, ads, etc.).
+            </p>
+
+            <p><strong>Note:</strong> there must be only one main content area. On some pages, defining what constitutes the main content can be challenging, like on homepages for instance.
+            </p>
+            <p>See the technical definition as defined by the ARIA API: <a href="https://www.w3.org/WAI/PF/aria/roles#main">Main (role)</a>.
+
+            <ul class="navTheme">
+                <li><a href="#m">Skip to M</a></li>
+                <li><a href="#o">Skip to O</a></li>
+            </ul>
+            <h2 id="n">N</h2>
+
+            <h3 id="mNameRole">
+                Name, role, value, settings and states changes
+            </h3>
+            <p>A user interface component must have appropriate role and name; its values, states and parameters (if any) must also be available and correctly conveyed to accessibility APIs, in particular.</p>
+            <p>The name may be the component's text content, like the label of a button, for example. </p>
+            <p>The value may be the selected item of a select list, or the current value of a slider, for example.</p>
+
+            <p>The role of an element is defined by the HTML specification (native roles, like for the button tag for example) or the WAI-ARIA API (ARIA role="button", for example).
+            </p>
+
+            <p>The settings are the information specific to a component, generally defined via the WAI-ARIA API. For example, <code>aria-controls</code> is a parameter informing the APIs that the component controls another one (referenced via its <code>id</code> attribute).
+            </p>
+
+            <p>The states changes are generally conveyed via the WAI-ARIA API. For instance <code>aria-expanded</code> is a state informing the accessibility APIs that the component is "expanded" or "collapsed". <strong>Note:</strong> a state can also be conveyed by the name, when it is dynamically changed to match the current state of the component, for instance.
+            </p>
+            <p>These parameters are not mandatory, but may be required if they are needed to make the component accessible. When testing for accessibility, the assessor must decide, based on the context where the component is used, if these parameters are required.</p>
+            <p>The assessor must also check that they are implemented according to the specifications, when they are used.</p>
+            <p><strong>Note:</strong> the ARIA roles, properties and states are implemented via attributes, like <code>role="banner"</code>, or <code>aria-hidden="true"</code> for instance.</p>
+
+
+
+            <h3 id="mBarreNav">Navigation bar</h3>
+            <p>
+
+                List of links providing a means to navigate in the website, in a category or in a collection of pages. The main navigation bars are:</p>
+            <ul>
+                <li>The main navigation menu</li>
+                <li>A breadcrumb trail</li>
+                <li>A navigation list of a results list</li>
+                <li>The menu of a subcategory</li>
+            </ul>
+            <h3 id="mMenuNav">
+                Navigation area, Navigation menu
+            </h3>
+
+            <p>Area with a list of links, giving access to the main parts of the website. Most of times, the navigation menus are the main and secondary menus.
+            </p>
+            <p>Note: links found in the footer, pointing to the credits page, the legal information page, the sitemap, and other site-related information pages, are not considered as a navigation menu.</p>
+            <p>See the technical definition of a navigation area provided by the WAI-ARIA API: <a href="http://www.w3.org/WAI/PF/aria/roles#navigation">navigation (role)</a>.</p>
+
+
+            <h3 id="mSysNav">
+                Navigation system
+            </h3>
+
+            <p>Any process allowing to navigate in the website or in a page. In the RGAA, the considered  navigation systems are:
+            </p>
+            <ul>
+                <li>Main navigation menu</li>
+                <li>Table of contents</li>
+                <li>Site map</li>
+                <li>Search engine</li>
+
+            </ul>
+
+            <h3 id="mMediaNoTemp">
+                Non time-based media
+            </h3>
+            <p>
+                Content that is not time-dependant, that can be played via a plugin (Flash, Java, Silverlight&hellip;) or via <code>svg</code> and <code>canvas</code> tags. For example, an interactive map in Flash, a Flash-based or Java application, a user-controlled slideshow, are non time-based media. A non time-based media can contain time-based media (a Flash-based gallery of videos, for example).</p>
+
+            <p><strong>Note :</strong> the use of the <code>wmode</code> parameter for a Flash object with the values "<code>transparent</code>" and "<code>opaque</code>" invalidates criterion 4.21 (Can each non time-based media be controlled by the keyboard and by the mouse?). When accessed with a  screenreader, these values make the Flash movie inaccessible (the object is ignored, or can not be browsed). therefore it can not be tabbed to.</p>
+
+            <ul class="navTheme">
+                <li><a href="#n">Skip to N</a></li>
+                <li><a href="#p">Skip to P</a></li>
+            </ul>
+            <h2 id="o">O</h2>
+            <!-- Only for layout -->
+            <h3 id="mUniquPres">
+                Only for layout
+            </h3>
+
+            <p>Only for layout: use of HTML tags for a purpose  different from what  is intended by specifications (with regard to the declared document type). Examples: use of <code>H<i>n</i></code> tags only to apply tyhe associated typographical effect; use of the <code>blockquote</code> tag only to indent a block of text, etc.</p>
+            <p><strong>Note 1:</strong> the use of DIV or SPAN elements for paragraphs is considered as a non conforming use of these elements, and invalidates the criterion.
+            </p>
+            <p><strong>Note 2:</strong> WAI-ARIA provides the <code>presentation</code> role, which suppresses the semantics of an element. For example: <code>&lt;h1 role=presentation"&gt;Title&lt;/h1&gt;</code>. In this example, the text content will be rendered, but not the role of heading (the rendered element will be undefined, in the form of <code>&lt;&gt;Title&lt;&gt;).</code></p>
+            <p>The <code>presentation</code> role may be required for some ARIA design patterns.It can also be used to suppress semantics on an element used only for layout. For example: <code>&lt;blockquote role=presentation"&gt;</code> will have the same effect as an absence of <code>blockquote</code> element.  </p>
+            <p>Although authors are strongly advised against this technique (because it will fail for older assistive technologies that do not support ARIA, for instance), it can be considered as WCAG conformant. However, assigning a <code>presentation</code> role to an element whose nature (i.e., its semantics) is essential to understand the content, is a viloation of the WCAG recommendations (see <a href="https://www.w3.org/TR/2015/NOTE-WCAG20-TECHS-20150226/F92">Failure F92</a>) et invalidates the criterion.</p>
+
+            <ul class="navTheme">
+                <li><a href="#o">Skip to O</a></li>
+                <li><a href="#r">Skip to R</a></li>
+            </ul>
+            <h2 id="p">P</h2>
+
+            <h3 id="#PageHeader">
+                Page Header
+            </h3>
+
+            <p>
+                Also called banner. Content block, starting a web page, and containing generally the document's headline, a logo, a baseline&hellip;
+            </p>
+
+            <p><strong>Note:</strong> this header must not be mistaken with section headers, which can be defined in HTML5 with the <code>header</code> tag in any sectioning element.
+            </p>
+            <p>See the technical definition of a banner as defined by the ARIA API: <a href="https://www.w3.org/WAI/PF/aria/roles#banner">Banner (role)</a>.
+            </p>
+            <h3 id="#mFontSize">
+                Percentage of the default font size
+            </h3>
+            <p>150% and 120% of the default font size: these two dimensions define the relative font size equivalent to 18 point (non-bold), and 14 points (bold), respectively, considering that the body font size is set at 100%.
+            </p>
+            <p>
+                The default font size is defined by the author for the document body; and if not specified, the default font size for the user agent (a browser, generally). In most current browsers, the default font size is set at 16 pixels.
+            </p>
+
+            <h3 id="mDOM">
+                Properties and methods compliant with the DOM (Document Object Model) specification</h3>
+            <p>The content insertion methods compliant with the DOM specification use properties and methods of the Node object, as opposed to proprietary methods; for example <code>document.write</code>, specific to the Internet Explorer/Microsoft, for legacy IE browsers.
+            </p>
+            <ul class="navTheme">
+                <li><a href="#p">Skip to P</a></li>
+                <li><a href="#s">Skip to S</a></li>
+            </ul>
+            <h2 id="r">R</h2>
+            <h3 id="mSensLecture">
+                Reading direction
+            </h3>
+
+            <p>Indicates the reading direction of the document or of a chunk of text via the <code>dir</code> attribute. The three accepted values are:</p>
+
+            <ul>
+                <li> <code>ltr</code> (left to right) indicates a reading direction from the left to the right;</li>
+                <li><code>rtl</code> (right to left) indicates a reading direction from the right to the left;
+                </li>
+                <li><code>auto</code>, which lets the browser determine the reading direction based ont the Unicode characters it finds in content.</li>
+            </ul>
+            <p><strong>Note:</strong> When the dir attribute is not set, the default reading direction is from left to right ("ltr" value).
+            </p>
+
+
+
+            <h3 id="mProcedeRafraichissement">
+                Refresh process
+            </h3>
+            <p>
+                Technique aiming at modifying the content of one or several elements of the Web page. The refresh process can be performed by automatic reloading of the page, or in a dynamic way without reloading the page (via AJAX, for example). The user must be able to control each refresh process in an independent way.</p>
+
+            <h3 id="mPertinence">
+                Relevance (information not conveyed through color only)
+            </h3>
+
+            <p>The means to retrieve information other than through color must be accessible for all. For example, in the case of a list of articles where articles with texts in yellow are discounted, the use of hidden text via CSS is a means to retrieve information "discounted", but it is not relevant because this information will remain hidden for users who browse the page with CSS enabled.
+            </p>
+            <p><strong>Note:</strong> The use of an emphasis tag (<code>strong</code> or <code>em</code>) as another means to retrieve information conveyed by color, validates the criterion, although these elements are generally not supported by assistive technologies, including screen readers.
+            </p>
+            <ul class="navTheme">
+                <li><a href="#r">Skip to R</a></li>
+                <li><a href="#t">Skip to T</a></li>
+            </ul>
+            <h2 id="s">S</h2>
+
+            <h3 id="#mScript">
+                Script
+            </h3>
+            <p>Computer code generally presented as  a list of instructions (in JavaScript, for example). Client-side scripting languages require a compatible browser where they are enabled. The instructions of a  client-side scripting language can be either embedded  in the HTML code, or fetched from  an external file. In both cases, scripts are included  via  <code>script</code> tags.
+            </p>
+
+
+            <h3 id="mMoteurRecherche">
+                Search engine (internal to a website)
+            </h3>
+            <p>Component of the site with which the user can perform searches on all the site's contents.
+            </p>
+            <p><strong>Note:</strong> this site-scaled search engine should not be confused with other search engines specific to a subparts of the site's contents, like the products of an online catalogue, or the list of public calls for tenders on a purchasing platform.
+            </p>
+            <p>See the technical definition of a search engine as defined by the ARIA API: <a href="https://www.w3.org/WAI/PF/aria/roles#search">search (role)</a>.
+            </p>
+
+
+            <h3 id="mListeChoix">
+                Selection list
+            </h3>
+
+            <p>Form field designed to select  items in a pull-down list (<code>select</code> tag with <code>option</code> tags).</p>
+
+            <h3 id="mEnsemblePages">
+                Set of pages
+            </h3>
+
+            <p>Pages linked to each other through links, and constituent a consistent set inside of a website. For example, the pages of an electronic payment process, the pages of a specific category, the pages of a blog, the pages to manage an account are sets of pages.
+            </p>
+            <p> <strong>Note:</strong> A website's home page can be considered as a "set of pages" (with only one element), as it can be quite  different from the rest of the site.
+            </p>
+
+            <h3 id="mPlanSite">
+                "Site map" page
+            </h3>
+
+            <p>Dedicated page presenting the structure of a Web site, generally as lists of categories and subcategories, with links giving access to al the site's pages.
+            </p>
+            <p><strong>Note 1:</strong> the site map's links may be implemented with <code>a</code> or <code>area</code> tags.
+            </p>
+            <p><strong>Note 2:</strong> it is not necessary that the site map lists the links to all the site's pages; however, starting from the site map page, the user should be able to reach every page on the site.
+            </p>
+
+            <h3 id="mTexteStyle">
+                Styled text
+            </h3>
+
+            <p>Text for which presentation is entirely controlled by a style properties, as opposed to by presentational tags.</p>
+
+            <h3 id="mCompAccess">
+                Supported by assistive technologies
+            </h3>
+
+            <p>A content or a functionality must be supported by users' assistive technologies, as well as the accessibility features in browsers and other user agents via an accessibility API.
+            </p>
+
+            <p>This concerns the technology, its features and its uses at the same time:</p>
+
+            <ul>
+                <li> The way the  technology is used must be supported by users' assistive technology. This means that the way  the technology is used has been tested for interoperability with users' assistive technologies in the human language(s) of the content,</li>
+                <li>the technology is supported natively in widely-distributed user agents that are also accessibility supported (such as HTML and CSS) or in a widely-distributed plugin that is also accessibility supported.</li>
+
+            </ul>
+            Checking for support by assistive technologies requires to perform  tests that are specific to the technology used. For instance:
+            <ul>
+
+                <li>checking the name, role, value and states changes of user interface components;</li>
+                <li>checking that a user interface component is correctly rendered by the considered assistive technologies.</li>
+
+            </ul>
+            <h3 id="mFeuilleStyle">
+                Style sheet
+            </h3>
+
+            <p>Set of instructions, written in CSS, a standardized language used to defined the layout of content elements in an HTML document (examples: page background color, text size/font/color, position in the page&hellip;). Style sheets can be external (CSS file), embedded (declared in the <code>head</code>) or inline (declared via the <code>style</code> attribute of a tag).
+            </p>
+            <h3 id="mResumeTab">
+                Summary (of a table)
+            </h3>
+            <p>A table summary is a chunk of text associated with a complex data table. It provides information on the nature and structure of the table, in order to ease its consultation for users of assistive technologies, for instance.
+            </p>
+            <p><strong>Note:</strong> the <code>summary</code> attribute is obsolete non conformant in HTML5, and must not be used anymore.
+            </p>
+            <p>
+                Among the 5 techniques proposed by the HTML5 specification, the only one that should be used currently consists in inserting the summary in the table title (<code>caption</code> tag), and hiding it with CSS if necessary.
+            </p>
+            <p>
+                Read the <a href="./RGAA3.0_Technical_notes_English_version_v1.html#TNcrit5-1">Technical note on table summaries</a>.
+            </p>
+
+            <h3 id="mSsTitreSynchro">
+                Synchronised captions (media object)
+            </h3>
+
+            <p>Synchronized visual and/or text alternative for both speech and non-speech audio information (including spoken dialogue, but also equivalents for non-dialogue audio information needed to understand the program content, including sound effects, music, laughter, speaker identification and location), needed to understand the media content.</p>
+            <p> <strong>Note 1:</strong> In order to differentiate audio sources (different speakers, voice off screen&hellip;), it is recommended to use an appropriate mechanism (square brackets, italics, explicit mention like "voice off screen:&hellip;").</p>
+            <p><strong>Note 2:</strong> captions should not be mistaken with subtitles, although both words may be used for the same usage in some countries. "Captions" (<code>kind="captions"</code> in HTML5) refer to  alternatives aiming at fulfilling the needs of people who are deaf or hard-of-hearing, while "subtitles" (<code>kind="subtitle"</code> in HTML5) refer to translation of spoken content in a different human language. Only captions will be considered to check conformance against the RGAA.
+            </p>
+            <ul class="navTheme">
+                <li><a href="#s">Skip to S</a></li>
+                <li><a href="#u">Skip to U</a></li>
+            </ul>
+            <h2 id="t">T</h2>
+
+            <h3 id="mOrdTab">
+                Tabbing order
+            </h3>
+
+            <p>Order in which the focus moves (to the next element or to the previous element). The natural order is the order of the source code. When it is modified by the use of the <code>tabindex</code> attribute or by scripting, then the modified order is the reference.</p>
+            <p> <strong>Warning:</strong> During testing, when an element initiates a change in the document (change of context, management of hidden areas, content addition, management of form fields&hellip;) it is necessary to trigger this change and check that the consistence of the tabbing order is preserved.
+            </p>
+
+            <h3 id="mTabDonneeComplexe">
+                Table (complex data table)
+            </h3>
+
+            <p>
+                <a href="#mTabDonnee"></a>Data tables are considered as complex, in the RGAA, when they have header cells outside of the first row and/or column, or whose scope does not cover the whole row or column. For these tables it is necessary to provide a summary, to describe their nature and structure, in order to ease its consultation by assistive technologies users, in particular.
+            </p>
+
+            <h3 id="mTabDonnee">
+                Table (data table)
+            </h3>
+
+            <p>HTML element (<code>table</code> tag) allowing to structure data in rows and columns via data cells (<code>td</code> tag) and header cells (<code>th</code> tag).
+            </p>
+
+            <h3 id="mTabMiseForme">
+                Table (for layout)
+            </h3>
+
+            <p>Web design technique based on the TABLE and TD elements to position  contents on screen.
+            </p>
+
+            <h3 id="mImgTest">
+                Test image
+            </h3>
+
+            <p>Image used in a test, a <a href="#mcaptcha">CAPTCHA</a> or an image used for a test in a quiz or a game. Example: a series of images present a detail from famous paintings; the title and the painter of each painting must be found. In this case, it is not possible to provide a relevant alternative (e.g. the painting title and/or painter) without making the test useless. The alternative must then only provide the ability to identify the image; for example "image 1 of the test".
+            </p>
+
+            <h3 id="mLienTexte">
+                Text link
+            </h3>
+
+            <p>Link whose content between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> is only constituted of text (called the link text). </p>
+
+            <h3 id="mTranscriptTextuel">
+                Text transcript (time-based media)
+            </h3>
+            <p>
+                Text content associated with a time-based media through the appropriate technique (text in HTML, or in a text file located in the same page, or accessed via a hyperlink). Without having to play the media content, the user should be able to fully understand it, based on the audio and visual information transcripted. Only significant and useful information (audio and visual) should be included.</p>
+
+            <p>This textual information must be presented in the same chronological order as  in the time-based media.
+            </p><p>Note: if the media is served via an <code>object</code> tag, then the text transcript must not be inside of the <code>object</code> tag.
+            </p>
+
+            <h3 id="mMediaTemp">
+                Time-based media (sound, video or synchronized)
+            </h3>
+
+            <ul>
+                <li>Audio-only time-based media: audio content (Wave, MP3&hellip;)</li>
+                <li>Video-only time-based media:  images or pictures moving or played in sequence
+                </li>
+                <li> Synchronised time-based media: audio or video feed synchronised with another time-based media to present information and/or having time-based interactive components. A time-based media can be played in 2 different ways:
+                    <ul>
+                        <li>  a downloadable file that can be played with a client, third-party software,</li>
+                        <li> content embedded in the Web page and that can be played inside the Web page via:
+                            <ul>
+                                <li>a plugin (example: a video played via a Flash-based player)</li>
+                                <li>the <code>video</code> element (a video clip, for instance)</li>
+                                <li>the <code>audio</code> element (a podcast, for instance)</li>
+                                <li>the <code>svg</code> element (an animated vector movie, for instance)</li>
+                                <li>the <code>canvas</code> element (an animated bitmap movie, for instance)</li>
+                            </ul>
+                        </li>
+
+                    </ul>
+                </li>
+
+            </ul>
+            <p>
+                A time-based media can be broadcast live or be provided to play in an asynchronous way (prerecorded media).</p>
+
+            <p><strong>Note :</strong> the use of the <code>wmode</code> parameter for a Flash object with the values "<code>transparent</code>" and "<code>opaque</code>" invalidates criterion 4.21 (Can each non time-based media be controlled by the keyboard and by the mouse?). When accessed with a  screenreader, these values make the Flash movie inaccessible (the object is ignored, or can not be browsed). therefore it can not be tabbed to.</p>
+            <p>
+                Note 2: Animated GIFs, and JavaScript-based animations  are not considered as time-based media with regards to RGAA.</p>
+
+
+            <h3 id="mTitreTab">
+                Title (of a data table)
+            </h3>
+
+            <p>Content of an HTML element (<code>caption</code> tag) describing the content of a data table. To be accessible the description must be relevant (clear and concise).
+            </p>
+
+            <h3 id="mTitrePage">
+                Title (of a page)
+            </h3>
+
+            <p>Content of the <code>title</code> tag of a Web page, describing in a clear, concise and unique fashion, the page content/nature ("site map www.sitename.fr" for a page dedicated to the sitemap of the sitename.fr site, for example).
+            </p>
+
+            <ul class="navTheme">
+                <li><a href="#t">Skip to T</a></li>
+                <li><a href="#v">Skip to V</a></li>
+            </ul>
+            <h2 id="u">U</h2>
+            <h3 id="mUrl">
+                URL
+            </h3>
+
+            <p>Uniform Resource Locator: a string of characters identifying the location of a resource and secifying the means to act upon it or obtain its representation. Also refered as "web address", on the Web it is applied to identify and provide access to HTML documents, web pages, images, sounds&hellip;
+            </p>
+            <p><strong>Note:</strong> In the RGAA, the term URL is used instead of URI (Uniform Resource Identifier, a URL being a specific type of URI).
+            </p>
+            <ul class="navTheme">
+                <li><a href="#u">Skip to U</a></li>
+                <li><a href="#w">Skip to W</a></li>
+            </ul>
+            <h2 id="v">V</h2>
+            <h3 id="mCodeValide">
+                Valid code
+            </h3>
+            <ul>
+                <li>Case of an HTML page: code in which the implementation of tags and attributes repects the specifications of the declared document type.
+                    <ul>
+                        <li><strong>Note 1:</strong> Unless specified, attributes that are not defined in Web standards specifications are not applicable.</li>
+                        <li><strong>Note 2:</strong> Unless specified, elements that are not defined in Web standards specifications are not applicable.</li>
+                        <li><strong>Note 3:</strong> <a href="http://www.w3.org/TR/xhtml1/#C_3">guideline C3 of the XHTML specification ("Element Minimization and Empty Element Content")</a> states that the use of minimized elements (<code>&lt;elm /&gt;</code>) for empty elements (for example &lt;p /&gt; instead of &lt;p&gt;&lt;/p&gt;) is not advised. This practice constitutes a non-conformance with regards to RGAA.
+                        </li>
+                    </ul>
+
+                <li>Case of a page that implements WAI ARIA: code in which the implementation of tags and attributes follows the specifications of the declared document type and in which WAI ARIA implementation conforms to the WAI ARIA specification.</li>
+
+            </ul>
+
+            <h3 id="mVectorLink">
+                Vector link
+            </h3>
+
+            <p>Link whose content between <code>&lt;a href="&hellip;"&gt;</code> and <code>&lt;/a&gt;</code> is only constituted of a vector image (svg tag). The link text of a vector link is the alternative text of the vector image.
+            </p>
+
+            <h3 id="mVisibleContent">
+                Visible content
+            </h3>
+            <p>For Test 10.2.1: "available content" means that the visible content remains available when CSS styles have been disabled. For instance, an image conveying information, used as a background through CSS, fails this test, since information is not "available" when CSS styles are disabled. However,  an image conveying information, used as a background through CSS, but accompanied by a hidden text, passes this test because information is "available" when CSS styles are disabled.</p>
+            <p>
+                <strong>Note:</strong> authors are formally advised against using images conveying information as CSS backgrounds, even when hidden texts are available.
+            </p>
+            <p class="navTheme"><a href="#y">Skip to V</a></p>
+
+            <h2 id="w">W</h2>
+            <h3 id="mSiteWeb">
+                Website
+            </h3>
+            <p>Set of Web pages:</p>
+            <ul>
+                <li>linked by hyperlinks,</li>
+                <li>belonging to the same domain name (eg.: references.modernisation.gouv.fr),</li>
+                <li>constituting a coherent whole from the user point of view.
+                </li>
+            </ul>
+            <p>Particular case: pages of a subdomain. A subdomain can:</p>
+            <ul>
+
+                <li>either belong to the Web site associated with the domain name, if the user has a similar browsing experience as with the other pages of the Web site (for example: same structure, same navigation&hellip;),
+                </li>
+                <li>    or not belong to the Web site associated with the domain name (for example: a blogging platform where all blogs have their own subdomain of the same domain, but bear no similiraties nor relationships with each other).
+                </li>
+            </ul>
+        </main>
+    </body>
 </html>

--- a/RGAA3.0_Particular_cases_English_version_v1.html
+++ b/RGAA3.0_Particular_cases_English_version_v1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="content-type" content="charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
     <title>RGAA 3.0 Particular cases - English translation</title>
         <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Particular cases." name="description" />

--- a/RGAA3.0_References_English_version_v1.html
+++ b/RGAA3.0_References_English_version_v1.html
@@ -1,95 +1,95 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta http-equiv="content-type" content="charset=UTF-8" />
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-    <title>RGAA 3.0 References - English translation</title>
-    <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. References." name="description" />
-    <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, references" name="keywords" />
+        <title>RGAA 3.0 References - English translation</title>
+        <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. References." name="description" />
+        <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, references" name="keywords" />
 
- </head>
-  <body>
-    <header role="banner">
-      <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
-      <nav id="nav" role="navigation">
-        <ul>
-          <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
-          <li><a href="./RGAA3.0_Glossary_English_version_v1.html">Glossary</a></li>
-          <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
-          <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
-          <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
-          <li>References</li>
-        </ul>
-      </nav>
-      <h1>References</h1>
-<p>
-The RGAA has been written using a number of references and documentary sources. This document lists the references that were used.
-</p>
-      <p>
-        This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
-      </p>
-      <p>
-        The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
-	<p>
-        Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
-      </p>
-      <p>
-        Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
-      </p>
-        <h2 id="toc">
-          Table of Contents
-        </h2>
-        <nav role="navigation" aria-labelledby="toc">
-          <ul>
-             <li><a href="#reference">Reference documents</a></li>
-             <li><a href="#other">Other documents</a></li>
-          </ul>
-        </nav>
-    </header>
+    </head>
+    <body>
+        <header role="banner">
+            <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
+            <nav id="nav" role="navigation">
+                <ul>
+                    <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
+                    <li><a href="./RGAA3.0_Glossary_English_version_v1.html">Glossary</a></li>
+                    <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
+                    <li><a href="./RGAA3.0_Technical_Notes_English_version_v1.html">Technical notes</a></li>
+                    <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
+                    <li>References</li>
+                </ul>
+            </nav>
+            <h1>References</h1>
+            <p>
+                The RGAA has been written using a number of references and documentary sources. This document lists the references that were used.
+            </p>
+            <p>
+                This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
+            </p>
+            <p>
+                The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
+            <p>
+                Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
+            </p>
+            <p>
+                Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
+            </p>
+            <h2 id="toc">
+                Table of Contents
+            </h2>
+            <nav role="navigation" aria-labelledby="toc">
+                <ul>
+                    <li><a href="#reference">Reference documents</a></li>
+                    <li><a href="#other">Other documents</a></li>
+                </ul>
+            </nav>
+        </header>
 
-    <main role="main">
+        <main role="main">
 
 
-<h2 id="reference">Reference documents</h2>
+            <h2 id="reference">Reference documents</h2>
 
-<ol>
-<li>Approved French translation "<a hreflang="fr" lang="fr" href="http://www.w3.org/Translations/WCAG20-fr/">Règles pour l'accessibilité des contenus Web (WCAG) 2.0</a>"
-</li>
-<li><a href="http://www.w3.org/TR/WCAG20-TECHS/">Techniques For WCAG&nbsp;2</a>
-</li>
-<li><a href="http://www.w3.org/TR/html401/">HTML 4.01 Specification
-</li>
-<li><a href="http://www.w3.org/TR/html5/">HTML5 A vocabulary and associated APIs for HTML and XHTML</a> as of October 2014
-</li>
-<li><a href="http://www.w3.org/html/wg/drafts/html/master/">HTML 5.1 Nightly A vocabulary and associated APIs for HTML and XHTML</a> as of July 2014
-</li>
-<li><a href="http://w3c.github.io/aria-in-html/">Using WAI-ARIA in HTML</a> as of June 2014
-</li>
-<li><a href="http://dev.w3.org/html5/alt-techniques/Overview.html">HTML5: Techniques for providing useful text alternatives</a> as of October 2012
-</li>
-<li><a href="http://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (WAI-ARIA) 1.0</a> as of March 2014
-</li>
-<li><a href="http://www.w3.org/WAI/PF/aria-practices/">WAI-ARIA 1.0 Authoring Practices</a> as of April 2014
-</li>
-</ol>
+            <ol>
+                <li>Approved French translation "<a hreflang="fr" lang="fr" href="http://www.w3.org/Translations/WCAG20-fr/">Règles pour l'accessibilité des contenus Web (WCAG) 2.0</a>"
+                </li>
+                <li><a href="http://www.w3.org/TR/WCAG20-TECHS/">Techniques For WCAG&nbsp;2</a>
+                </li>
+                <li><a href="http://www.w3.org/TR/html401/">HTML 4.01 Specification</a>
+                </li>
+                <li><a href="http://www.w3.org/TR/html5/">HTML5 A vocabulary and associated APIs for HTML and XHTML</a> as of October 2014
+                </li>
+                <li><a href="http://www.w3.org/html/wg/drafts/html/master/">HTML 5.1 Nightly A vocabulary and associated APIs for HTML and XHTML</a> as of July 2014
+                </li>
+                <li><a href="http://w3c.github.io/aria-in-html/">Using WAI-ARIA in HTML</a> as of June 2014
+                </li>
+                <li><a href="http://dev.w3.org/html5/alt-techniques/Overview.html">HTML5: Techniques for providing useful text alternatives</a> as of October 2012
+                </li>
+                <li><a href="http://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (WAI-ARIA) 1.0</a> as of March 2014
+                </li>
+                <li><a href="http://www.w3.org/WAI/PF/aria-practices/">WAI-ARIA 1.0 Authoring Practices</a> as of April 2014
+                </li>
+            </ol>
 
-<h2 id="other">Other documents</h2>
-<ol>
-<li><a href="http://www.w3.org/WAI/GL/wiki/Main_Page">Web Content Accessibility Guidelines Working Group (Wiki)</a>
-</li>
-<li><a href="http://rawgit.com/w3c/html-api-map/master/index.html">HTML to Platform Accessibility APIs Implementation Guide</a> as of July 2014
-</li>
-<li><a href="http://www.w3.org/TR/UAAG20/">User Agent Accessibility Guidelines (UAAG) 2.0</a> as of November 2013
-</li>
-<li><a href="http://www.w3.org/WAI/AU/ATAG20/">Authoring Tool Accessibility Guidelines (ATAG) 2.0</a> as of October 2013
-</li>
-<li><a href="http://www.w3.org/TR/wai-aria-implementation/">WAI-ARIA 1.0 User Agent Implementation Guide</a> as of March 2014
-</li>
-<li><a href="http://rawgit.com/w3c/aria/master/spec/aria.html">Accessible Rich Internet Applications (WAI-ARIA) 1.1</a> as of July 2014
-</li>
-<li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a> as of June 2014
-</li>
-</ol>
-  </main>
-</body>
+            <h2 id="other">Other documents</h2>
+            <ol>
+                <li><a href="http://www.w3.org/WAI/GL/wiki/Main_Page">Web Content Accessibility Guidelines Working Group (Wiki)</a>
+                </li>
+                <li><a href="http://rawgit.com/w3c/html-api-map/master/index.html">HTML to Platform Accessibility APIs Implementation Guide</a> as of July 2014
+                </li>
+                <li><a href="http://www.w3.org/TR/UAAG20/">User Agent Accessibility Guidelines (UAAG) 2.0</a> as of November 2013
+                </li>
+                <li><a href="http://www.w3.org/WAI/AU/ATAG20/">Authoring Tool Accessibility Guidelines (ATAG) 2.0</a> as of October 2013
+                </li>
+                <li><a href="http://www.w3.org/TR/wai-aria-implementation/">WAI-ARIA 1.0 User Agent Implementation Guide</a> as of March 2014
+                </li>
+                <li><a href="http://rawgit.com/w3c/aria/master/spec/aria.html">Accessible Rich Internet Applications (WAI-ARIA) 1.1</a> as of July 2014
+                </li>
+                <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a> as of June 2014
+                </li>
+            </ol>
+        </main>
+    </body>
 </html>

--- a/RGAA3.0_Technical_Notes_English_version_v1.html
+++ b/RGAA3.0_Technical_Notes_English_version_v1.html
@@ -1,203 +1,203 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta http-equiv="content-type" content="charset=UTF-8" />
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-    <title>RGAA 3.0 Technical notes - English translation</title>
-    <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Technical notes." name="description" />
-    <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, technical notes" name="keywords" />
-  
- </head>
-  <body>  
-    <header role="banner">
-      <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
-      <nav id="nav" role="navigation">
-        <ul>
-          <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
-          <li><a href="./RGAA3.0_Glossary_English_version_v1.html">Glossary</a></li>
-          <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
-          <li>Technical notes</li>
-          <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
-          <li><a href="./RGAA3.0_References_English_version_v1.html">References</a></li>
-        </ul>
-      </nav>
-      <h1>Technical Notes</h1>
-<p>
-The technical notes below provide explanations regarding some HTML5 elements whose support can be inconsistent across different user agents, and propositions made by the RGAA  to circumvent potential issues.
+        <title>RGAA 3.0 Technical notes - English translation</title>
+        <meta content="English translation of the RGAA 3.0, French official accessibility guidelines. Technical notes." name="description" />
+        <meta content="RGAA, RGAA 3.0, French accessibility guidelines, English translation, technical notes" name="keywords" />
 
-</p>
-      <p>
-        This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
-      </p>
-      <p>
-        The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
-	<p>
-        Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
-      </p>
-      <p>
-        Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
-      </p>
-        <h2 id="toc">
-          Table of Contents
-        </h2>
-        <nav role="navigation" aria-labelledby="toc">
-          <ul>
-             <li><a href="#images">Images</a></li>
-             <li><a href="#tableaux">Tables</a></li>
-            <li><a href="#script">Scripts</a></li>
-            <li><a href="#structure">Information structure</a></li>
-            <li><a href="#presentation">Presentation of information</a></li>
-            <li><a href="#formulaire">Forms</a></li>
-            <li><a href="#navigation">Navigation</a></li>
-          </ul>
-        </nav>
-    </header>
+    </head>
+    <body>  
+        <header role="banner">
+            <p id="skiplinks"><a href="#toc">Table of Contents</a></p>
+            <nav id="nav" role="navigation">
+                <ul>
+                    <li><a href="./RGAA3.0_Criteria_English_version_v1.html">Criteria</a></li>
+                    <li><a href="./RGAA3.0_Glossary_English_version_v1.html">Glossary</a></li>
+                    <li><a href="./RGAA3.0_Particular_cases_English_version_v1.html">Particular cases</a></li>
+                    <li>Technical notes</li>
+                    <li><a href="./RGAA3.0_Baseline_English_version_v1.html">Baseline</a></li>
+                    <li><a href="./RGAA3.0_References_English_version_v1.html">References</a></li>
+                </ul>
+            </nav>
+            <h1>Technical Notes</h1>
+            <p>
+                The technical notes below provide explanations regarding some HTML5 elements whose support can be inconsistent across different user agents, and propositions made by the RGAA  to circumvent potential issues.
 
-    <main role="main">
+            </p>
+            <p>
+                This document is a property of the French government, under <a hreflang="fr" href="http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence">Open License 1.0 (in French)</a> or later, as all documents hosted on <a href="http://references.modernisation.gouv.fr/">references.modernisation.gouv.fr</a>. See the terms and conditions of the license in the <a href="http://references.modernisation.gouv.fr/mentions-legales">legal informations</a>.
+            </p>
+            <p>
+                The technical reference guidelines (list of criteria, glossary, particular cases, technical notes, baseline) are an adapted copy of the <a href="http://www.accessiweb.org/index.php/accessiweb-html5aria-liste-deployee.html">AccessiWeb HTML5 / ARIA</a> guidelines - Working Version as of 12/19/2013 - Edited by BrailleNet.</p>
+            <p>
+                Disclaimer: this translation is NOT normative. It is available for informational purposes only. The normative version is the <a hreflang="fr" href="http://references.modernisation.gouv.fr/referentiel-technique-0">official RGAA in French</a>.
+            </p>
+            <p>
+                Although greatest care has been taken during translation, we acknowledge the fact that this text probably contains mistakes. You may write to <a href="mailto:rgaa.sgmap@modernisation.gouv.fr">rgaa.sgmap@modernisation.gouv.fr</a> if you feel corrections are needed.
+            </p>
+            <h2 id="toc">
+                Table of Contents
+            </h2>
+            <nav role="navigation" aria-labelledby="toc">
+                <ul>
+                    <li><a href="#images">Images</a></li>
+                    <li><a href="#tableaux">Tables</a></li>
+                    <li><a href="#script">Scripts</a></li>
+                    <li><a href="#structure">Information structure</a></li>
+                    <li><a href="#presentation">Presentation of information</a></li>
+                    <li><a href="#formulaire">Forms</a></li>
+                    <li><a href="#navigation">Navigation</a></li>
+                </ul>
+            </nav>
+        </header>
 
-
-
-<h2>Images</h2>
-
-<h3 id="TNcrit1-1">Criterion 1.1 [A]</h3>
-
-<p>Except for <code>svg</code>, the <code>aria-label</code> and <code>aria-labelledby</code> attributes to provide an alternative text, or link the image to a chunk of text provided as an alternative text, can not be used due to lack of support by assistive technologies.
-</p>
-<p>The SVG specification recommends using a <code>&lt;title&gt;</code> element for the "short" description and a  <code>&lt;desc&gt;</code> element for the long description. Currently only the <code>&lt;desc&gt;</code> is rendered correctly by assistive technologies. The use of the <code>&lt;title&gt;</code> is considered not accessibility supported.
-</p>
-<h3 id="TNcrit1-2">Criterion 1.2 [A]</h3>
-
-<p>When an image is associated with a caption, the WCAG technical note  recommends to systematically provide an alternative text for the image (see criterion 1.10). In this case the criterion 1.2 is not applicable.
-</p>
-<p>A WAI-ARIA <code>role="presentation"</code> attribute  can not be used to specify a decorative image, in accordance with  the use of WAI-ARIA roles restrictions, as per the current specifications.
-</p>
-<h3 id="TNcrit1-3">Criterion 1.3 [A]</h3>
-
-<p>The WCAG note prohibits the use of the <code>title</code> attribute to replace the <code>alt</code> attribute, however it is often useful to use the <code>title</code> attribute to display a tooltip on particularly obscure images. If the <code>title</code> attribute is used in this way, the content of the <code>title</code> attribute must be strictly identical to the alternative.</p>
-
-<p>With SVG, the lack of support for the <code>&lt;title&gt;</code> element by assistive technologies incurs issues when the <code>&lt;desc&gt;</code> element is used to implement the  short alternative text for the image, whereas the image requires detailed description. In this case it is recommended to use an adjacent text or an adjacent link to provide the detailed description.
-</p>
-<p>The 1.3.7 and 1.3.9 tests are used to verify that the implementation of the alternative is accessibility supported (with the chosen <a href="./RGAA3.0_Baseline_English_version_v1.html">baseline</a>).
-</p>
-
-<h3 id="TNcrit1-6">Criterion 1.6 [A]</h3>
-
-<p>With SVG, the lack of support for the <code>&lt;title&gt;</code> element by assistive technologies incurs issues when the <code>&lt;desc&gt;</code> element is used to implement the  short alternative text for the image, whereas the image requires detailed description. In this case it is recommended to use an adjacent text or an adjacent link to provide the detailed description.
-</p>
-
-<p>If the <code>&lt;desc&gt;</code> element is used to implement the detailed description, it is recommended to use an <code>aria-label</code> attribute to implement the short alternative  of the image.
-</p>
-<p>The use of the <code>aria-describedby</code> attribute is not possible to link an image to its description, due to lack of support for assistive technologies.
-</p>
-<p>The adjacent detailed description can be implemented via a <code>&lt;figcaption&gt;</code> in this case the criterion 1.10 must be verified (using <code>&lt;figure&gt;</code>,  <code>role="group"</code>, etc.).
-</p>
-<h3>Criteria 1.8 [AA] and 1.9 [AAA]</h3>
-
-<p>The text in vector images being actual text, it is not affected by these criteria.</p>
-
-<h3 id="TNcrit1-10">Criterion 1.10 [A]</h3>
-
-<p>Implementing a <code>role="group"</code> on the <code>&lt;figure&gt;</code> parent element is intended to circumvent the current lack of support for the <code>&lt;figure&gt;</code> elements by assistive technologies. Although recommended, the use of a <code>figcaption</code> element in a  <code>figure</code> element is optional. However the use of a <code>figcaption</code> element to associate a caption to an image requires the use of a <code>figure</code> parent element. The reference to the adjacent caption can be an expression like "image 1", or an equivalent, when this expression is included in the caption.
-</p>
-<p>Although recommended by HTML5, the WCAG Note states that the <code>title</code> attribute can not be used for to "label" an image.
-</p>
-<p>The <code>aria-labelledby</code>  and <code>aria-describedby</code> attributes can not be currently used, due to lack of support by assistive technologies.
-</p>
-<h2>Tables</h2>
-
-<h3 id="TNcrit5-1">Criterion 5.1 [A]</h3>
-
-<p>The specification provides several methods to associate a table with its summary (table linked to a text passage with <code>aria-describedby</code>; table grouped with a summary, provided as an adjacent text, via a <code>figure</code> element; table grouped with a summary, provided in a <code>figcaption</code> element, via a <code>figure</code> element; summary provided via a <code>details</code> element in the <code>caption</code> element).
-</p>
-<p>These methods are currently not  supported enough to be used reliably.</p>
-
-<h2>Scripts</h2>
-
-<h3 id="TNcrit7-1">Alternative to JavaScript and compatibility of user interface components with assistive technologies</h3>
-
-<p>Criterion 7.1 implements the concept of "compatible with assistive technologies" as defined by the WCAG 2, as well as the use of WAI-ARIA API to make a component or  functionality accessible. The proper use of the WAI-ARIA API is verified through tests 7.1.3, 7.1.4, 7.1.5 and 7.1.6.</p>
-
-<p><strong>Important note</strong>: in an HTML5 environment, many components may require JavaScript to function. In the case of a JavaScript component that could not be made ​​accessible, when an alternative is provided, a method must be provided specifically for the faulty component to enable the user to replace it (or turn it on again) with its accessible alternative.</p>
-
-<p>This means that disabling JavaScript for the whole page will not be accepted as a valid method, unless it does not compromize the use of other components.
-</p>
-<h3 id="TNcrit7-3">Criterion 7.3 [A]</h3>
-
-<p>For certain user interface components design patterns, ARIA defines a set of keyboard interactions  based on Esc, Spacebar, Tab and arrow keys; and, occasionally, other interactions based on Page Up, Page Down, Home and End keys, for example. In order to allow gradual implementation of these components with complex keyboard interactions, the RGAA restricts the requirements to only main keys (Esc, Spacebar, Tab, Arrow keys) as per the <a href="./RGAA3.0_Glossary_English_version_v1.html#motif-de-conception">ARIA  design patterns.
-</p>
-<h2>Information structure</h2>
-
-<h3 id="TNcrit9-1">Criterion 9.1 [A]</h3>
-
-<p>The ARIA specification allows the use of the role <code>heading</code> combined with the <code>aria-level</code> property (hierarchical level in the document outline) to mark headings. Although it is preferable to use the native &lt;h<i>x</i>&gt; elements in HTML , the use of the WAI-ARIA role <code>heading</code> is compatible with accessibility.</p>
-
-<p>While the HTML5 specification allows the use of only level 1 headings (<code>&lt;h1&gt;</code>), the lack of support by assistive technologies makes it necessary to use a relevant headings hierarchy.
-</p>
-<h3 id="TNcrit9-2">Criterion 9.2 [A]</h3>
-
-<p>The document tree (outline) is generated by the use of sectioning<code> &lt;nav&gt;</code>, <code>&lt;article&gt;</code>, <code>&lt;section&gt;</code>, and <code>&lt;aside&gt;</code>  tags, and implicit sections generated by using a <code>&lt;h<i>x</i>&gt;</code> (when the <code>&lt;h<i>x</i>&gt;</code> is not the first child of a section).</p>
-
-<p>A sectioning tag is used to structure or group content, parts of a content, or a set of contents that can be considered independently of the rest of the document.
-</p>
-<p>A navigation area in the site or in a subpart of the site, a table of contents or the navigation area of a collection of pages (<code>&lt;nav&gt;</code>), a content "complementary" to main content (<code>&lt;aside&gt;</code>), the main content or the grouping of several content like articles (<code>&lt;article&gt;</code> or <code>&lt;section&gt;</code>) or a secondary content such as a comment, a Twitter widget, RSS feeds (<code>&lt;article&gt;</code> or <code>&lt;section&gt;</code>) are examples of sectioning contents.
-</p>
-<p>In the case of content, as opposed to the navigation areas (<code>&lt;nav&gt;</code>) or complementary content areas (<code>&lt;aside&gt;</code>), a section should have, if appropriate, a header (<code>&lt;header&gt;</code>) and footer (<code>&lt;footer&gt;</code>).
-</p>
-<p>The first heading <code>&lt;h<i>x</i>&gt;</code> in a section gives the "name" of this section, as it will be set in the document tree. The following headings (<code>&lt;h<i>x</i>&gt;</code>;) create implicit sections that will constitute  the section's outline.</p>
-
-<p>A section can be considered independently of the rest of the page, the tree generated by the implicit sections (<code>&lt;h<i>x</i>&gt;</code>) is calculated from Level 1 assigned to the first section heading.</p>
-
-<p>When used, the document tree may therefore be different from the page content tree based on <code>&lt;h<i>x</i>&gt;</code>, although both structures are similar.
-</p>
-
-<p>This tree must be representative of the document structure and be consistent with the structure of the content generated by the use of <code>&lt;h<i>x</i>&gt;</code>. Structuring the content generated by the <code>&lt;h<i>x</i>&gt;</code> tags could be, theoretically, deduced from the document tree, thus the HTML5 specification recommends using <code>&lt;h1&gt;</code> headings. But this practice is prohibited by RGAA and requires via the criterion 9.1 to use a relevant headings hierarchy  (<code>&lt;h<i>x</i>&gt;</code>).</p>
-
-<p>If the outline (provided that it is relevant) allows  exploration and navigation features with some assistive technologies, it also affects the headings hierarchy generated by the <code>&lt;h<i>x</i>&gt;</code> by changing the level of rendered headings.</p>
-
-<p>To accompany the gradual support of the document outline algorithm, and considering the fact that the RGAA requires to have, in any case, a robust and consistent content structure (tags <code>&lt;h<i>x</i>&gt;</code>), it is acceptable to consider the test 9.2.2 as not applicable when it is not possible to ensure that the document outline is perfectly consistent.
-</p>
-<p>In this case, non-compliant content for this test should be signaled as a simple warning.</p>
-
-<h3 id="TNcrit9-3">Criterion 9.3 [A]</h3>
-
-<p>The WAI-ARIA Roles <code>list</code> and  <code>listitem</code>  may require the use of the <code>aria-setsize</code> and <code>aria-posinset</code> properties, if the entire list is not available via the DOM generated at the time of rendering.</p>
-
-<p>Despite the existence of the <code>definition</code> role, used in combination with the <code>aria-labelledby</code> property, WAI-ARIA does not offer a role equivalent  to HTML definition lists (<code>DL</code>). The  <code>definition</code> role can not, therefore, be used as an equivalent of an HTML definition list <code>DL</code>.</p>
-
-<p>The roles <code>tree</code>, <code>tablist</code>, <code>menu</code>, <code>combobox</code> and <code>listbox</code> are not equivalent to an HTML <code>ul</code> or <code>ol</code> list.
-</p>
-<p>References: <a href="http://www.w3.org/WAI/PF/aria/roles#list"></a>The Role Model,  List Role</a> and <a href="http://www.w3.org/WAI/PF/aria/states_and_properties#aria-setsize">The role model - ARIA SETSIZE</a>.</p>
-
-<h3 id="TNcrit9-4">Criterion 9.4 [AAA]</h3>
+        <main role="main">
 
 
-<p>Despite the existence of the <code>definition</code> role, used in combination with the <code>aria-labelledby</code> property, WAI-ARIA does not offer a role equivalent  to HTML definition lists (<code>DL</code>). The  <code>definition</code> role can not, therefore, be used as an equivalent of an HTML definition list <code>DL</code>.</p>
 
-<h2>Presentation of information</h2>
+            <h2>Images</h2>
 
-<h3 id="TNcrit10-13">Criterion 10.13 [A]</h3>
+            <h3 id="TNcrit1-1">Criterion 1.1 [A]</h3>
 
-<p>WAI-ARIA provides an <code>aria-hidden</code> property (<code>true</code> or <code>false</code>) that inhibits the rendering of a content to assistive technologies, without affecting its visibility with visual user agents: content with <code>aria-hidden="true"</code> will not be spoken out but remains visible. Unless the content controlled by <code>aria-hidden</code> is not intended to be rendered by assistive technologies, the value of the <code>aria-hidden</code> attribute must be consistent with the displayed or hidden status of the on-screen content.
-</p>
-<p>The HTML5 specification describes a <code>hidden</code> attribute that can make unavailable (when the hidden attribute is present) content in the generated DOM (similar to <code>type="hidden"</code> on a form control). Unless the content controlled by <code>hidden</code> is not intended to be rendered by assistive technologies, the value of the <code>hidden</code> attribute must be consistent with the displayed or hidden status of the on-screen content.</p>
+            <p>Except for <code>svg</code>, the <code>aria-label</code> and <code>aria-labelledby</code> attributes to provide an alternative text, or link the image to a chunk of text provided as an alternative text, can not be used due to lack of support by assistive technologies.
+            </p>
+            <p>The SVG specification recommends using a <code>&lt;title&gt;</code> element for the "short" description and a  <code>&lt;desc&gt;</code> element for the long description. Currently only the <code>&lt;desc&gt;</code> is rendered correctly by assistive technologies. The use of the <code>&lt;title&gt;</code> is considered not accessibility supported.
+            </p>
+            <h3 id="TNcrit1-2">Criterion 1.2 [A]</h3>
 
-<p>There can be situations where a  content controlled with <code>hidden</code> or <code>aria-hidden</code> is momentarily in an inconsistent state with the displayed or hidden  status of the content, for example when an item is meant to be available but visually displayed only upon further action. In this case, it is the final state of the content that should be considered for validation of this criterion.</p>
+            <p>When an image is associated with a caption, the WCAG technical note  recommends to systematically provide an alternative text for the image (see criterion 1.10). In this case the criterion 1.2 is not applicable.
+            </p>
+            <p>A WAI-ARIA <code>role="presentation"</code> attribute  can not be used to specify a decorative image, in accordance with  the use of WAI-ARIA roles restrictions, as per the current specifications.
+            </p>
+            <h3 id="TNcrit1-3">Criterion 1.3 [A]</h3>
 
-<h2>Forms</h2>
+            <p>The WCAG note prohibits the use of the <code>title</code> attribute to replace the <code>alt</code> attribute, however it is often useful to use the <code>title</code> attribute to display a tooltip on particularly obscure images. If the <code>title</code> attribute is used in this way, the content of the <code>title</code> attribute must be strictly identical to the alternative.</p>
 
-<h3 id="TNcrit11-11">Criterion 11.11 [AA]</h3>
+            <p>With SVG, the lack of support for the <code>&lt;title&gt;</code> element by assistive technologies incurs issues when the <code>&lt;desc&gt;</code> element is used to implement the  short alternative text for the image, whereas the image requires detailed description. In this case it is recommended to use an adjacent text or an adjacent link to provide the detailed description.
+            </p>
+            <p>The 1.3.7 and 1.3.9 tests are used to verify that the implementation of the alternative is accessibility supported (with the chosen <a href="./RGAA3.0_Baseline_English_version_v1.html">baseline</a>).
+            </p>
+
+            <h3 id="TNcrit1-6">Criterion 1.6 [A]</h3>
+
+            <p>With SVG, the lack of support for the <code>&lt;title&gt;</code> element by assistive technologies incurs issues when the <code>&lt;desc&gt;</code> element is used to implement the  short alternative text for the image, whereas the image requires detailed description. In this case it is recommended to use an adjacent text or an adjacent link to provide the detailed description.
+            </p>
+
+            <p>If the <code>&lt;desc&gt;</code> element is used to implement the detailed description, it is recommended to use an <code>aria-label</code> attribute to implement the short alternative  of the image.
+            </p>
+            <p>The use of the <code>aria-describedby</code> attribute is not possible to link an image to its description, due to lack of support for assistive technologies.
+            </p>
+            <p>The adjacent detailed description can be implemented via a <code>&lt;figcaption&gt;</code> in this case the criterion 1.10 must be verified (using <code>&lt;figure&gt;</code>,  <code>role="group"</code>, etc.).
+            </p>
+            <h3>Criteria 1.8 [AA] and 1.9 [AAA]</h3>
+
+            <p>The text in vector images being actual text, it is not affected by these criteria.</p>
+
+            <h3 id="TNcrit1-10">Criterion 1.10 [A]</h3>
+
+            <p>Implementing a <code>role="group"</code> on the <code>&lt;figure&gt;</code> parent element is intended to circumvent the current lack of support for the <code>&lt;figure&gt;</code> elements by assistive technologies. Although recommended, the use of a <code>figcaption</code> element in a  <code>figure</code> element is optional. However the use of a <code>figcaption</code> element to associate a caption to an image requires the use of a <code>figure</code> parent element. The reference to the adjacent caption can be an expression like "image 1", or an equivalent, when this expression is included in the caption.
+            </p>
+            <p>Although recommended by HTML5, the WCAG Note states that the <code>title</code> attribute can not be used for to "label" an image.
+            </p>
+            <p>The <code>aria-labelledby</code>  and <code>aria-describedby</code> attributes can not be currently used, due to lack of support by assistive technologies.
+            </p>
+            <h2>Tables</h2>
+
+            <h3 id="TNcrit5-1">Criterion 5.1 [A]</h3>
+
+            <p>The specification provides several methods to associate a table with its summary (table linked to a text passage with <code>aria-describedby</code>; table grouped with a summary, provided as an adjacent text, via a <code>figure</code> element; table grouped with a summary, provided in a <code>figcaption</code> element, via a <code>figure</code> element; summary provided via a <code>details</code> element in the <code>caption</code> element).
+            </p>
+            <p>These methods are currently not  supported enough to be used reliably.</p>
+
+            <h2>Scripts</h2>
+
+            <h3 id="TNcrit7-1">Alternative to JavaScript and compatibility of user interface components with assistive technologies</h3>
+
+            <p>Criterion 7.1 implements the concept of "compatible with assistive technologies" as defined by the WCAG 2, as well as the use of WAI-ARIA API to make a component or  functionality accessible. The proper use of the WAI-ARIA API is verified through tests 7.1.3, 7.1.4, 7.1.5 and 7.1.6.</p>
+
+            <p><strong>Important note</strong>: in an HTML5 environment, many components may require JavaScript to function. In the case of a JavaScript component that could not be made ​​accessible, when an alternative is provided, a method must be provided specifically for the faulty component to enable the user to replace it (or turn it on again) with its accessible alternative.</p>
+
+            <p>This means that disabling JavaScript for the whole page will not be accepted as a valid method, unless it does not compromize the use of other components.
+            </p>
+            <h3 id="TNcrit7-3">Criterion 7.3 [A]</h3>
+
+            <p>For certain user interface components design patterns, ARIA defines a set of keyboard interactions  based on Esc, Spacebar, Tab and arrow keys; and, occasionally, other interactions based on Page Up, Page Down, Home and End keys, for example. In order to allow gradual implementation of these components with complex keyboard interactions, the RGAA restricts the requirements to only main keys (Esc, Spacebar, Tab, Arrow keys) as per the <a href="./RGAA3.0_Glossary_English_version_v1.html#motif-de-conception">ARIA  design patterns</a>.
+            </p>
+            <h2>Information structure</h2>
+
+            <h3 id="TNcrit9-1">Criterion 9.1 [A]</h3>
+
+            <p>The ARIA specification allows the use of the role <code>heading</code> combined with the <code>aria-level</code> property (hierarchical level in the document outline) to mark headings. Although it is preferable to use the native &lt;h<i>x</i>&gt; elements in HTML , the use of the WAI-ARIA role <code>heading</code> is compatible with accessibility.</p>
+
+            <p>While the HTML5 specification allows the use of only level 1 headings (<code>&lt;h1&gt;</code>), the lack of support by assistive technologies makes it necessary to use a relevant headings hierarchy.
+            </p>
+            <h3 id="TNcrit9-2">Criterion 9.2 [A]</h3>
+
+            <p>The document tree (outline) is generated by the use of sectioning<code> &lt;nav&gt;</code>, <code>&lt;article&gt;</code>, <code>&lt;section&gt;</code>, and <code>&lt;aside&gt;</code>  tags, and implicit sections generated by using a <code>&lt;h<i>x</i>&gt;</code> (when the <code>&lt;h<i>x</i>&gt;</code> is not the first child of a section).</p>
+
+            <p>A sectioning tag is used to structure or group content, parts of a content, or a set of contents that can be considered independently of the rest of the document.
+            </p>
+            <p>A navigation area in the site or in a subpart of the site, a table of contents or the navigation area of a collection of pages (<code>&lt;nav&gt;</code>), a content "complementary" to main content (<code>&lt;aside&gt;</code>), the main content or the grouping of several content like articles (<code>&lt;article&gt;</code> or <code>&lt;section&gt;</code>) or a secondary content such as a comment, a Twitter widget, RSS feeds (<code>&lt;article&gt;</code> or <code>&lt;section&gt;</code>) are examples of sectioning contents.
+            </p>
+            <p>In the case of content, as opposed to the navigation areas (<code>&lt;nav&gt;</code>) or complementary content areas (<code>&lt;aside&gt;</code>), a section should have, if appropriate, a header (<code>&lt;header&gt;</code>) and footer (<code>&lt;footer&gt;</code>).
+            </p>
+            <p>The first heading <code>&lt;h<i>x</i>&gt;</code> in a section gives the "name" of this section, as it will be set in the document tree. The following headings (<code>&lt;h<i>x</i>&gt;</code>;) create implicit sections that will constitute  the section's outline.</p>
+
+            <p>A section can be considered independently of the rest of the page, the tree generated by the implicit sections (<code>&lt;h<i>x</i>&gt;</code>) is calculated from Level 1 assigned to the first section heading.</p>
+
+            <p>When used, the document tree may therefore be different from the page content tree based on <code>&lt;h<i>x</i>&gt;</code>, although both structures are similar.
+            </p>
+
+            <p>This tree must be representative of the document structure and be consistent with the structure of the content generated by the use of <code>&lt;h<i>x</i>&gt;</code>. Structuring the content generated by the <code>&lt;h<i>x</i>&gt;</code> tags could be, theoretically, deduced from the document tree, thus the HTML5 specification recommends using <code>&lt;h1&gt;</code> headings. But this practice is prohibited by RGAA and requires via the criterion 9.1 to use a relevant headings hierarchy  (<code>&lt;h<i>x</i>&gt;</code>).</p>
+
+            <p>If the outline (provided that it is relevant) allows  exploration and navigation features with some assistive technologies, it also affects the headings hierarchy generated by the <code>&lt;h<i>x</i>&gt;</code> by changing the level of rendered headings.</p>
+
+            <p>To accompany the gradual support of the document outline algorithm, and considering the fact that the RGAA requires to have, in any case, a robust and consistent content structure (tags <code>&lt;h<i>x</i>&gt;</code>), it is acceptable to consider the test 9.2.2 as not applicable when it is not possible to ensure that the document outline is perfectly consistent.
+            </p>
+            <p>In this case, non-compliant content for this test should be signaled as a simple warning.</p>
+
+            <h3 id="TNcrit9-3">Criterion 9.3 [A]</h3>
+
+            <p>The WAI-ARIA Roles <code>list</code> and  <code>listitem</code>  may require the use of the <code>aria-setsize</code> and <code>aria-posinset</code> properties, if the entire list is not available via the DOM generated at the time of rendering.</p>
+
+            <p>Despite the existence of the <code>definition</code> role, used in combination with the <code>aria-labelledby</code> property, WAI-ARIA does not offer a role equivalent  to HTML definition lists (<code>DL</code>). The  <code>definition</code> role can not, therefore, be used as an equivalent of an HTML definition list <code>DL</code>.</p>
+
+            <p>The roles <code>tree</code>, <code>tablist</code>, <code>menu</code>, <code>combobox</code> and <code>listbox</code> are not equivalent to an HTML <code>ul</code> or <code>ol</code> list.
+            </p>
+            <p>References: <a href="http://www.w3.org/WAI/PF/aria/roles#list">The Role Model,  List Role</a> and <a href="http://www.w3.org/WAI/PF/aria/states_and_properties#aria-setsize">The role model - ARIA SETSIZE</a>.</p>
+
+            <h3 id="TNcrit9-4">Criterion 9.4 [AAA]</h3>
 
 
-<p>Some types of HTML5 form controls manage help messages on input automatically. For example, input fields of type  <code>email</code> display a message like "Please enter a valid email address" if the entered email address does not match the expected format. These messages are customizable via the API Constraint Validation, which provides ability to customize error messages. This validates the criterion, however, authors are warned that support of this API is not yet stabilized. The <code>pattern</code> type that can automatically perform format control (using regular expressions) also displays a help message but it is customizable via the <code>title</code> attribute; this mechanism validates the criterion.
-</p>
-<p>Reference: <a href="http://www.whatwg.org/specs/web-apps/current-work/#constraint-validation">WHATWG - 4.10.21.3 The constraint validation API</a>.
-</p>
-<h2>Navigation</h2>
+            <p>Despite the existence of the <code>definition</code> role, used in combination with the <code>aria-labelledby</code> property, WAI-ARIA does not offer a role equivalent  to HTML definition lists (<code>DL</code>). The  <code>definition</code> role can not, therefore, be used as an equivalent of an HTML definition list <code>DL</code>.</p>
 
-<h3 id="TNcrit12-10">Criterion 12.10 [A]</h3>
+            <h2>Presentation of information</h2>
 
-<p>WAI-ARIA provides roles to indicate the main areas (regions) of the document. These roles are very beneficial to users of screen readers in particular, but also to sighted  keyboard users who can benefit from features allowing rapid navigation  in the document structure. While most screen readers make  these features available to users, browsers have not yet proposed dedicated navigation features for users who rey on keyboard eclusively. The implementation of skip links remains a requirement.</p>
+            <h3 id="TNcrit10-13">Criterion 10.13 [A]</h3>
 
-  </main>
-</body>
+            <p>WAI-ARIA provides an <code>aria-hidden</code> property (<code>true</code> or <code>false</code>) that inhibits the rendering of a content to assistive technologies, without affecting its visibility with visual user agents: content with <code>aria-hidden="true"</code> will not be spoken out but remains visible. Unless the content controlled by <code>aria-hidden</code> is not intended to be rendered by assistive technologies, the value of the <code>aria-hidden</code> attribute must be consistent with the displayed or hidden status of the on-screen content.
+            </p>
+            <p>The HTML5 specification describes a <code>hidden</code> attribute that can make unavailable (when the hidden attribute is present) content in the generated DOM (similar to <code>type="hidden"</code> on a form control). Unless the content controlled by <code>hidden</code> is not intended to be rendered by assistive technologies, the value of the <code>hidden</code> attribute must be consistent with the displayed or hidden status of the on-screen content.</p>
+
+            <p>There can be situations where a  content controlled with <code>hidden</code> or <code>aria-hidden</code> is momentarily in an inconsistent state with the displayed or hidden  status of the content, for example when an item is meant to be available but visually displayed only upon further action. In this case, it is the final state of the content that should be considered for validation of this criterion.</p>
+
+            <h2>Forms</h2>
+
+            <h3 id="TNcrit11-11">Criterion 11.11 [AA]</h3>
+
+
+            <p>Some types of HTML5 form controls manage help messages on input automatically. For example, input fields of type  <code>email</code> display a message like "Please enter a valid email address" if the entered email address does not match the expected format. These messages are customizable via the API Constraint Validation, which provides ability to customize error messages. This validates the criterion, however, authors are warned that support of this API is not yet stabilized. The <code>pattern</code> type that can automatically perform format control (using regular expressions) also displays a help message but it is customizable via the <code>title</code> attribute; this mechanism validates the criterion.
+            </p>
+            <p>Reference: <a href="http://www.whatwg.org/specs/web-apps/current-work/#constraint-validation">WHATWG - 4.10.21.3 The constraint validation API</a>.
+            </p>
+            <h2>Navigation</h2>
+
+            <h3 id="TNcrit12-10">Criterion 12.10 [A]</h3>
+
+            <p>WAI-ARIA provides roles to indicate the main areas (regions) of the document. These roles are very beneficial to users of screen readers in particular, but also to sighted  keyboard users who can benefit from features allowing rapid navigation  in the document structure. While most screen readers make  these features available to users, browsers have not yet proposed dedicated navigation features for users who rey on keyboard eclusively. The implementation of skip links remains a requirement.</p>
+
+        </main>
+    </body>
 </html>

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,7 @@
+include.path=${php.global.include.path}
+php.version=PHP_54
+source.encoding=UTF-8
+src.dir=.
+tags.asp=false
+tags.short=false
+web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.php.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/php-project/1">
+            <name>rgaa_referentiel_en</name>
+        </data>
+    </configuration>
+</project>


### PR DESCRIPTION
Here are the fixes for HTML grammar errors in the 6 HTML files. Errors were found thanks to https://validator.w3.org/nu/
I had to change also indentation to have a "graphical / hierarchical" view of the code.
I intentionally left the `nbproject/` directory (2 files) so that users may open it directly with Netbeans. No worry if you want to remove those files.
This is a first Pull Request (PR) before submitting another one with some CSS styling to beautify the page :)
